### PR TITLE
fix(filter): include both .test. and .spec. as default

### DIFF
--- a/goals.md
+++ b/goals.md
@@ -1,3 +1,11 @@
-- **fix:** include both .test. and .spec. as default filter
+# Goals
+
+## `fix:`
+
+---
+
+## `feat:`
+
 - **feat:** show message from `assert` like in popular "describe" and "it" if `describe` option is `true`
 - **feat:** show individual test execution time
+- **feat:** allow to limit concurrency in parallel runs

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -12,3 +12,6 @@ export const format = {
   success: (value: string) => `\x1b[32m${value}\x1b[0m`,
   fail: (value: string) => `\x1b[31m${value}\x1b[0m`,
 };
+
+export const getLargestStringLength = (arr: string[]): number =>
+  arr.reduce((max, current) => Math.max(max, current.length), 0);

--- a/src/helpers/hr.ts
+++ b/src/helpers/hr.ts
@@ -1,9 +1,20 @@
 import { EOL } from 'node:os';
 import process from 'node:process';
 
-export const hr = () => {
-  const columns = process.stdout.columns;
-  const line = '⎯'.repeat(columns - 10 || 30);
+let lastLenght: number = 0;
 
-  console.log(`\x1b[2m${line}\x1b[0m${EOL}`);
+export const hr = (size?: number) => {
+  const pad = 10;
+  const limit = process.stdout.columns - pad;
+  const fileLenght = typeof size === 'number' ? Math.floor(size / 2) + pad : 0;
+  const columns =
+    fileLenght > 0 && fileLenght <= limit
+      ? fileLenght
+      : lastLenght > 0
+        ? lastLenght
+        : limit;
+  const line = '⎯'.repeat(columns);
+  lastLenght = columns;
+
+  console.log(`${EOL}\x1b[2m${line}\x1b[0m${EOL}`);
 };

--- a/src/modules/list-files.ts
+++ b/src/modules/list-files.ts
@@ -16,7 +16,7 @@ export const listFiles = (
   configs?: Configs
 ) => {
   const currentFiles = fs.readdirSync(dirPath);
-  const defaultRegExp = /\.test\./i;
+  const defaultRegExp = /\.(test|spec)\./i;
   const filter: RegExp =
     (envFilter
       ? envFilter

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -5,7 +5,7 @@ import { runner } from '../helpers/runner.js';
 import { indentation } from '../helpers/indentation.js';
 import { listFiles } from '../modules/list-files.js';
 import { hr } from '../helpers/hr.js';
-import { format } from '../helpers/format.js';
+import { format, getLargestStringLength } from '../helpers/format.js';
 import { runTestFile } from './run-test-file.js';
 import { Configs } from '../@types/poku.js';
 import { isQuiet } from '../helpers/logs.js';
@@ -24,7 +24,7 @@ export const runTests = async (
   let passed = true;
 
   if (showLogs) {
-    hr();
+    hr(getLargestStringLength(files));
     console.log(
       `${format.bold('Directory:')} ${format.underline(currentDir)}${EOL}`
     );

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://poku.dev/sitemap.xml


### PR DESCRIPTION
Now it's possible to use `*.spec.*` and `*.test.*` without config filter to reach on them.