### PR TITLE
feat: support target file and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,13 @@ Enjoying **Poku**? Consider giving him a star ⭐️
 
 ---
 
-🐷 [**Documentation Website**](https://poku.dev) • 🔬 [**Compare Poku with the Most Popular Test Runners**](https://poku.dev/docs/comparing)
+🐷 [**Documentation Website**](https://poku.dev) • 🔬 [**Compare Poku with the Most Popular Test Runners**](https://poku.dev/docs/comparing) • 🧪 [**Examples**](https://poku.dev/docs/category/examples)
 
 ---
 
 ## Why Poku?
 
-Don't worry about `describe`, `it`, `beforeEach` and everything else 🚀 <br/>
-After all, you don't need to learn what you already know ([**see why**](https://poku.dev/docs/examples/beforeEach)) ✨
+Let's make `describe`, `beforeEach` and everything else easier ([**see why and how**](https://poku.dev/docs/examples/beforeEach)) 🚀 <br/>
 
 - Supports **ESM** and **CJS**
 - Designed to be highly intuitive
@@ -62,6 +61,12 @@ After all, you don't need to learn what you already know ([**see why**](https://
 ## Documentation
 
 - See detailed usage in [**Documentation**](https://poku.dev/docs/category/documentation) section for **Poku**'s **CLI**, **API (_in-code_)** and **assert**, advanced concepts and much more.
+
+---
+
+## Examples
+
+- See real example usages in [**Examples**](https://poku.dev/docs/category/examples) section for **Poku**'s + **Mock**, **Virutal DOM** and more.
 
 ---
 
@@ -117,47 +122,58 @@ import { poku } from 'npm:poku';
 
 ## Quick Start
 
-### CLI
+### `poku`
+
+#### CLI
+
+> Try to set the flag `--parallel` before the target path 🚀
 
 > <img src=".github/assets/readme/node-js.svg" width="24" />
 
 ```bash
-npx poku targetDir
+npx poku targetPath
+npx poku targetPathA,targetPathB
 ```
 
 > <img src=".github/assets/readme/bun.svg" width="24" />
 
 ```bash
-bun poku targetDir
+bun poku targetPath
+bun poku targetPathA,targetPathB
 ```
 
 > <img src=".github/assets/readme/deno.svg" width="24" />
 
 ```bash
-deno run npm:poku targetDir
+deno run npm:poku targetPath
+deno run npm:poku targetPathA,targetPathB
 ```
 
-### API (_In-code_)
+#### API (_In-code_)
 
-#### Node.js, TypeScript (Node.js) and Bun
+##### Node.js, TypeScript (Node.js) and Bun
 
 ```ts
 import { poku } from 'poku';
 
-await poku(['targetDir']);
+await poku(['targetPath']);
 ```
 
-#### Deno
+##### Deno
 
 ```ts
 import { poku } from 'npm:poku';
 
-await poku(['targetDir']);
+await poku(['targetPath']);
 ```
+
+### `assert`
+
+Use it exactly as it's for **Node.js** 💚
 
 ---
 
-To see the detailed documentation, please visit the [**Documentation**](https://poku.dev/docs/category/documentation) section in the [**Poku**'s website](https://poku.dev).
+To see the detailed documentation, please visit the [**Documentation**](https://poku.dev/docs/category/documentation) and [**Examples**](https://poku.dev/docs/category/examples) sections in the [**Poku**'s website](https://poku.dev).
 
 ---
 

--- a/src/modules/list-files.ts
+++ b/src/modules/list-files.ts
@@ -16,6 +16,10 @@ export const sanitizePath = (input: string, ensureTarget?: boolean): string => {
 export const escapeRegExp = (string: string) =>
   string.replace(/[.*{}[\]\\]/g, '\\$&');
 
+export const isFile = (fullPath: string) => fs.statSync(fullPath).isFile();
+
+export const isDir = (fullPath: string) => fs.statSync(fullPath).isDirectory();
+
 const envFilter = process.env.FILTER?.trim()
   ? new RegExp(escapeRegExp(process.env.FILTER), 'i')
   : null;
@@ -46,8 +50,7 @@ export const listFiles = (
     if (/node_modules/.test(fullPath)) continue;
     if (exclude && exclude.some((regex) => regex.test(fullPath))) continue;
 
-    if (fs.statSync(fullPath).isDirectory())
-      listFiles(fullPath, files, configs);
+    if (isDir(fullPath)) listFiles(fullPath, files, configs);
     else if (filter.test(fullPath)) files.push(fullPath);
   }
 

--- a/src/modules/poku.ts
+++ b/src/modules/poku.ts
@@ -11,20 +11,20 @@ import { fileResults } from '../services/run-test-file.js';
 import { indentation } from '../helpers/indentation.js';
 
 export async function poku(
-  targetDirs: string | string[],
+  targetPaths: string | string[],
   configs: Configs & { noExit: true }
 ): Promise<Code>;
 export async function poku(
-  targetDirs: string | string[],
+  targetPaths: string | string[],
   configs?: Configs
 ): Promise<void>;
 export async function poku(
-  targetDirs: string | string[],
+  targetPaths: string | string[],
   configs?: Configs
 ): Promise<Code | void> {
   let code: Code = 0;
 
-  const prepareDirs = forceArray(targetDirs);
+  const prepareDirs = forceArray(targetPaths);
   const dirs = prepareDirs.length > 0 ? prepareDirs : ['./'];
   const showLogs = !isQuiet(configs);
 

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -3,7 +3,7 @@ import { EOL } from 'node:os';
 import path from 'node:path';
 import { runner } from '../helpers/runner.js';
 import { indentation } from '../helpers/indentation.js';
-import { listFiles, sanitizePath } from '../modules/list-files.js';
+import { isFile, listFiles, sanitizePath } from '../modules/list-files.js';
 import { hr } from '../helpers/hr.js';
 import { format } from '../helpers/format.js';
 import { runTestFile } from './run-test-file.js';
@@ -22,7 +22,7 @@ export const runTests = async (
   const cwd = process.cwd();
   const testDir = path.join(cwd, sanitizePath(dir));
   const currentDir = path.relative(cwd, testDir);
-  const files = listFiles(testDir, undefined, configs);
+  const files = isFile(dir) ? [dir] : listFiles(testDir, undefined, configs);
   const totalTests = files.length;
   const showLogs = !isQuiet(configs);
 
@@ -73,7 +73,7 @@ export const runTestsParallel = async (
 ): Promise<boolean> => {
   const cwd = process.cwd();
   const testDir = path.join(cwd, dir);
-  const files = listFiles(testDir, undefined, configs);
+  const files = isFile(dir) ? [dir] : listFiles(testDir, undefined, configs);
 
   const promises = files.map(async (filePath) => {
     const testPassed = await runTestFile(filePath, configs);

--- a/website/docs/documentation/poku/configs/debug.mdx
+++ b/website/docs/documentation/poku/configs/debug.mdx
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # `debug`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `debug: boolean`
 

--- a/website/docs/documentation/poku/configs/exclude.mdx
+++ b/website/docs/documentation/poku/configs/exclude.mdx
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # `exclude`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `exclude: RegExp | RegExp[]`
 

--- a/website/docs/documentation/poku/configs/filter.mdx
+++ b/website/docs/documentation/poku/configs/filter.mdx
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # `filter`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `filter: RegExp`
 

--- a/website/docs/documentation/poku/configs/no-exit.mdx
+++ b/website/docs/documentation/poku/configs/no-exit.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 
 # `noExit`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `noExit: boolean`
 

--- a/website/docs/documentation/poku/configs/parallel.mdx
+++ b/website/docs/documentation/poku/configs/parallel.mdx
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # `parallel`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `parallel: boolean`
 

--- a/website/docs/documentation/poku/configs/platform.mdx
+++ b/website/docs/documentation/poku/configs/platform.mdx
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # `platform`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `platform: "node" | "bun" | "deno"`
 

--- a/website/docs/documentation/poku/configs/quiet.mdx
+++ b/website/docs/documentation/poku/configs/quiet.mdx
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # `quiet`
 
-> `poku(targetDirs: string | string[], configs?: Configs)`
+> `poku(targetPaths: string | string[], configs?: Configs)`
 >
 > `quiet: boolean`
 

--- a/website/docs/documentation/poku/include-files.mdx
+++ b/website/docs/documentation/poku/include-files.mdx
@@ -4,18 +4,18 @@ sidebar_position: 1
 
 # Include Directories
 
-> `poku(targetDirs: string | string[])`
+> `poku(targetPaths: string | string[])`
 >
 > By default, **Poku** searches for _`.test.`_ and `.spec.` files, but you can customize it using the [`filter`](/docs/documentation/poku/configs/filter) option.
 
 ## API (_in-code_)
 
 ```ts
-poku('targetDir');
+poku('targetePath');
 ```
 
 ```ts
-poku(['targetDirA', 'targetDirB']);
+poku(['targetePathA', 'targetePathB']);
 ```
 
 ```ts
@@ -29,11 +29,11 @@ By setting the directories as the **last argument**:
 > _Since **1.3.0**_
 
 ```bash
-npx poku targetDir
+npx poku targetePath
 ```
 
 ```bash
-npx poku targetDirA,targetDirB
+npx poku targetePathA,targetePathB
 ```
 
 ```bash
@@ -44,11 +44,11 @@ npx poku
 By using `--include` option, you can use it in any order:
 
 ```bash
-npx poku --include='targetDir'
+npx poku --include='targetePath'
 ```
 
 ```bash
-npx poku --include='targetDirA,targetDirB'
+npx poku --include='targetePathA,targetePathB'
 ```
 
 ```bash

--- a/website/docs/examples/beforeEach.mdx
+++ b/website/docs/examples/beforeEach.mdx
@@ -122,7 +122,7 @@ assert.strictEqual(0, failuresCode, 'Running Failures Integration Tests');
 **Finally**
 
 ```bash
-node ./test/run.test.js
+npx poku test/run.test.js
 ```
 
-> Or `npx tsx ./test/run.test.ts` for **TypeScript**.
+> Or `npx poku test/run.test.ts` for **TypeScript**.

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -56,13 +56,17 @@ Enjoying **Poku**? Consider giving him a star ⭐️
 <div className='features black'>
   <p>
     <Success />
-    <span>You don't need to learn what you already know ✨</span>
+    <span>
+      Let's make `describe`, `beforeEach` and everything else easier ([**see why
+      and how**](/docs/examples/beforeEach)) 🚀
+    </span>
   </p>
   <p>
     <Success />
     <span>
-      Don't worry about `describe`, `it`, `beforeEach` and everything else
-      ([**see why**](/docs/examples/beforeEach)) 🚀
+      **Poku** brings human-friendly testing and assertion to
+      [**Node.js**][node-version-url], [**Bun**][bun-version-url] &
+      [**Deno**][deno-version-url] at the same time ✨
     </span>
   </p>
 </div>
@@ -125,7 +129,7 @@ import { poku } from 'https://esm.sh/poku';
     ```ts
     import { poku } from 'poku';
 
-    await poku(['targetDir']);
+    await poku(['targetPath']);
     ```
 
   </TabItem>
@@ -134,7 +138,7 @@ import { poku } from 'https://esm.sh/poku';
 ```ts
 import { poku } from 'npm:poku';
 
-await poku(['targetDir']);
+await poku(['targetPath']);
 ```
 
   </TabItem>
@@ -146,21 +150,21 @@ await poku(['targetDir']);
   <TabItem default value='Node.js and TypeScript (Node.js)'>
 
 ```bash
-npx poku targetDir
+npx poku targetPath
 ```
 
   </TabItem>
   <TabItem  value='Bun'>
 
 ```bash
-bun poku targetDir
+bun poku targetPath
 ```
 
   </TabItem>
   <TabItem  value='Deno'>
 
 ```bash
-deno run npm:poku targetDir
+deno run npm:poku targetPath
 ```
 
     **Poku** requires these permissions by default:

--- a/website/src/css/home.scss
+++ b/website/src/css/home.scss
@@ -173,7 +173,6 @@
             & > small {
               width: 100%;
               text-align: center;
-              hyphens: auto;
               text-shadow: 1px 1px 1px #13152dab;
               font-family: 'Montserrat', sans-serif;
               font-size: 15px;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -185,9 +185,8 @@ const Home = () => {
               </div>
               <footer>
                 <small>
-                  <Silhouette width={13} /> Don't worry about{' '}
-                  <code>describe</code>, <code>it</code>,{' '}
-                  <code>beforeEach</code> and everything else 🚀
+                  <Silhouette width={13} /> Let's make <code>describe</code>,{' '}
+                  <code>beforeEach</code> and everything else easier 🚀
                 </small>
                 <div className='custom-code-block'>
                   npm i -D poku


### PR DESCRIPTION
Now it's possible to use both target dir and files to **Poku**:

```bash
npx poku test/my-file.js
npx poku test/my-file.ts
```

```bash
npx poku --parallel test/my-file-a.js,my-file-b.ts
```


```bash
npx poku --parallel test/my-file-a.js,test/my-dir,my-file-b.ts
```