### PR TITLE
feat: add `test` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,25 @@ deno run npm:poku
 
 ---
 
+## Available Methods
+
+### Essentials
+
+- `poku` (_test runner_)
+- `assert` and `assertPromise` (_test assertion_)
+
+### Helpers
+
+- `beforeEach` and `afterEach`
+- `test`
+- `describe` and `log`
+- `listFiles`
+- `exit`
+
+[**See the complete documentation**](https://poku.io/docs).
+
+---
+
 ## Overview
 
 ### `poku`

--- a/src/configs/each.ts
+++ b/src/configs/each.ts
@@ -6,6 +6,8 @@ export type Control = {
 
 export type EachConfigs = {
   status: boolean;
+  assert?: boolean;
+  test?: boolean;
   cb?: () => unknown | Promise<unknown>;
 };
 
@@ -16,9 +18,13 @@ export const each: {
   before: {
     status: true,
     cb: undefined,
+    assert: true,
+    test: true,
   },
   after: {
     status: true,
     cb: undefined,
+    assert: true,
+    test: true,
   },
 };

--- a/src/helpers/parseAsssetion.ts
+++ b/src/helpers/parseAsssetion.ts
@@ -25,7 +25,7 @@ export const parseAssertion = async (
   const FILE = process.env.FILE;
 
   try {
-    if (typeof each.before.cb === 'function') {
+    if (typeof each.before.cb === 'function' && each.before.assert) {
       const beforeResult = each.before.cb();
       if (beforeResult instanceof Promise) await beforeResult;
     }
@@ -33,7 +33,7 @@ export const parseAssertion = async (
     const cbResult = cb();
     if (cbResult instanceof Promise) await cbResult;
 
-    if (typeof each.after.cb === 'function') {
+    if (typeof each.after.cb === 'function' && each.after.assert) {
       const afterResult = each.after.cb();
       if (afterResult instanceof Promise) await afterResult;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { describe, log } from './modules/describe.js';
 export { assertPromise } from './modules/assert-promise.js';
 export { beforeEach, afterEach } from './modules/each.js';
 export { publicListFiles as listFiles } from './modules/list-files.js';
+export { test } from './modules/test.js';
 export type { Code } from './@types/code.ts';
 export type { Configs } from './@types/poku.ts';
 export type { Configs as ListFilesConfigs } from './@types/list-files.ts';

--- a/src/modules/each.ts
+++ b/src/modules/each.ts
@@ -2,6 +2,8 @@ import { Control, each } from '../configs/each.js';
 
 type EachOptions = {
   immediate?: boolean;
+  test?: boolean;
+  assert?: boolean;
 };
 
 /**
@@ -29,6 +31,10 @@ export const beforeEach = (
   callback: () => unknown,
   options?: EachOptions
 ): Control => {
+  each.before.test = typeof options?.test === 'boolean' ? options.test : true;
+  each.before.assert =
+    typeof options?.assert === 'boolean' ? options.assert : true;
+
   options?.immediate && callback();
 
   each.before.cb = () => {
@@ -71,7 +77,14 @@ export const beforeEach = (
  * after.reset();
  * ```
  */
-export const afterEach = (callback: () => unknown): Control => {
+export const afterEach = (
+  callback: () => unknown,
+  options: Omit<EachOptions, 'immediate'>
+): Control => {
+  each.after.test = typeof options?.test === 'boolean' ? options.test : true;
+  each.after.assert =
+    typeof options?.assert === 'boolean' ? options.assert : true;
+
   each.after.cb = () => {
     if (each.after.status) callback();
   };

--- a/src/modules/test.ts
+++ b/src/modules/test.ts
@@ -1,0 +1,20 @@
+import { each } from '../configs/each.js';
+
+export async function test(cb: () => Promise<unknown>): Promise<void>;
+export function test(cb: () => unknown): void;
+export async function test(
+  cb: () => unknown | Promise<unknown>
+): Promise<void> {
+  if (typeof each.before.cb === 'function' && each.before.test) {
+    const beforeResult = each.before.cb();
+    if (beforeResult instanceof Promise) await beforeResult;
+  }
+
+  const resultCb = cb();
+  if (resultCb instanceof Promise) await resultCb;
+
+  if (typeof each.after.cb === 'function' && each.after.test) {
+    const afterResult = each.after.cb();
+    if (afterResult instanceof Promise) await afterResult;
+  }
+}

--- a/website/docs/documentation/helpers/log.mdx
+++ b/website/docs/documentation/helpers/log.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # log

--- a/website/docs/documentation/helpers/test.mdx
+++ b/website/docs/documentation/helpers/test.mdx
@@ -1,0 +1,66 @@
+---
+sidebar_position: 3
+---
+
+# test
+
+> `test(() => void)`
+
+`test` is a helper to assist you in such cases:
+
+- Use the beforeEach and afterEach for each `test` performed
+- Isolate or group your tests in the same file
+
+```ts
+import { test, beforeEach, afterEach } from 'poku';
+
+const prepareService = () => true;
+const resetService = () => true;
+
+beforeEach(() => prepareService(), {
+  assert: false,
+});
+
+afterEach(() => resetService(), {
+  assert: false,
+});
+
+test(() => {
+  // do anything you want
+});
+
+test(() => {
+  // do anything you want
+});
+```
+
+:::info
+Ensure you disabled the assert on **beforeEach** and **afterEach**.
+:::
+
+## By using promises
+
+```ts
+import { test, beforeEach, afterEach } from 'poku';
+
+const prepareService = () =>
+  new Promise((resolve) => resolve(true), {
+    assert: false,
+  });
+
+const resetService = () =>
+  new Promise((resolve) => resolve(true), {
+    assert: false,
+  });
+
+beforeEach(async () => await prepareService());
+afterEach(async () => await resetService());
+
+await test(async () => {
+  // do anything you want
+});
+
+await test(async () => {
+  // do anything you want
+});
+```

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -99,13 +99,16 @@ const config: Config = {
       defaultMode: 'dark',
       respectPrefersColorScheme: false,
     },
+    algolia: {
+      appId: '8W3D1A9OL6',
+      apiKey: '7e1ef3de299364cedc6f3240f7f00063',
+      indexName: 'poku',
+      searchPagePath: false,
+      contextualSearch: false,
+    },
   } satisfies Preset.ThemeConfig,
 
-  plugins: [
-    'docusaurus-plugin-sass',
-    '@easyops-cn/docusaurus-search-local',
-    navbarLocalePlugin,
-  ],
+  plugins: ['docusaurus-plugin-sass', navbarLocalePlugin],
 };
 
 export default config;

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,7 +12,6 @@
         "@docusaurus/plugin-google-gtag": "^3.1.1",
         "@docusaurus/plugin-google-tag-manager": "^3.1.1",
         "@docusaurus/preset-classic": "^3.1.1",
-        "@easyops-cn/docusaurus-search-local": "^0.40.1",
         "@mdx-js/react": "^3.0.1",
         "clsx": "^2.1.0",
         "docusaurus-plugin-sass": "^0.2.5",
@@ -2809,85 +2808,6 @@
         "node": ">=18.0"
       }
     },
-    "node_modules/@easyops-cn/autocomplete.js": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
-      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "immediate": "^3.2.3"
-      }
-    },
-    "node_modules/@easyops-cn/docusaurus-search-local": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.40.1.tgz",
-      "integrity": "sha512-4HMFZMpKKdd5qq1nFB8cvrAkgzZ1kNxphVciI64YHtmDYGIthVGZVG6+Ci7AAhzCR+ixLJkYwtVekvuMLjr2ZQ==",
-      "dependencies": {
-        "@docusaurus/plugin-content-docs": "^2 || ^3",
-        "@docusaurus/theme-translations": "^2 || ^3",
-        "@docusaurus/utils": "^2 || ^3",
-        "@docusaurus/utils-common": "^2 || ^3",
-        "@docusaurus/utils-validation": "^2 || ^3",
-        "@easyops-cn/autocomplete.js": "^0.38.1",
-        "@node-rs/jieba": "^1.6.0",
-        "cheerio": "^1.0.0-rc.3",
-        "clsx": "^1.1.1",
-        "debug": "^4.2.0",
-        "fs-extra": "^10.0.0",
-        "klaw-sync": "^6.0.0",
-        "lunr": "^2.3.9",
-        "lunr-languages": "^1.4.0",
-        "mark.js": "^8.11.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@docusaurus/theme-common": "^2 || ^3",
-        "react": "^16.14.0 || ^17 || ^18",
-        "react-dom": "^16.14.0 || 17 || ^18"
-      }
-    },
-    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-0.45.0.tgz",
-      "integrity": "sha512-DPWjcUDQkCeEM4VnljEOEcXdAD7pp8zSZsgOujk/LGIwCXWbXJngin+MO4zbH429lzeC3WbYLGjE2MaUOwzpyw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-0.45.0.tgz",
-      "integrity": "sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
@@ -3563,255 +3483,6 @@
         "react": ">=16"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.1.1.tgz",
-      "integrity": "sha512-ATj9ua659JgrkICjJscaeZdmPr44cb/KFjNWuD0N6pux0SpzaM7+iOuuK11mAnQM2N9q0DT4REu6NkL8ZEhopw==",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^0.45.0",
-        "@emnapi/runtime": "^0.45.0",
-        "@tybys/wasm-util": "^0.8.1"
-      }
-    },
-    "node_modules/@node-rs/jieba": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.9.2.tgz",
-      "integrity": "sha512-H7/Pv9RBEgzcxVAM4yg6L4G10ZoiqVnNcUCs01yV9XIRwLmShUkdthkTqG8heyx2dAMRua+kofd28JtDWBHMfA==",
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@node-rs/jieba-android-arm-eabi": "1.9.2",
-        "@node-rs/jieba-android-arm64": "1.9.2",
-        "@node-rs/jieba-darwin-arm64": "1.9.2",
-        "@node-rs/jieba-darwin-x64": "1.9.2",
-        "@node-rs/jieba-freebsd-x64": "1.9.2",
-        "@node-rs/jieba-linux-arm-gnueabihf": "1.9.2",
-        "@node-rs/jieba-linux-arm64-gnu": "1.9.2",
-        "@node-rs/jieba-linux-arm64-musl": "1.9.2",
-        "@node-rs/jieba-linux-x64-gnu": "1.9.2",
-        "@node-rs/jieba-linux-x64-musl": "1.9.2",
-        "@node-rs/jieba-wasm32-wasi": "1.9.2",
-        "@node-rs/jieba-win32-arm64-msvc": "1.9.2",
-        "@node-rs/jieba-win32-ia32-msvc": "1.9.2",
-        "@node-rs/jieba-win32-x64-msvc": "1.9.2"
-      }
-    },
-    "node_modules/@node-rs/jieba-android-arm-eabi": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.9.2.tgz",
-      "integrity": "sha512-FbgUDCvek/KI4mJe5wqbbJi9kDE788YVvsA7DLTE0up+Tb/A7pNIJXq4Pg7zhsgHTVL7EfHHsyd89k+YoSU7Wg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-android-arm64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.9.2.tgz",
-      "integrity": "sha512-o6cZz5APAUVBCTG9tNK3XEcLunjGo7Oon1N8+1EHOHPlx4Twzhn1msBtQ+VCgboHUOI+QgZzlY/sTXGfh8IuIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-darwin-arm64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.9.2.tgz",
-      "integrity": "sha512-68Pk5phmgn/k5w6nzZWYkDHwJ5wYagprVaSf/WgcPVucw9kAzVMZasGxXo2+Kqn2kMWhD7Dm2NT1TAromQq8Eg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-darwin-x64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.9.2.tgz",
-      "integrity": "sha512-TXms+q4l7/0a7T+O9t5fQ0m6Qi+4XKgtaRmg089iYbvSp4JfX+XIg+ZLJG+9uc25oWpOgpt+z4bsz9rrHnW/6Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-freebsd-x64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.9.2.tgz",
-      "integrity": "sha512-U4p8PSm+1onheBJUKlEyP4VRE42UrH+gXDYMJlWiJDqriAjZLvA+MdF5xiqeppH0dWc/tQu/ECLoj1WXkJKfvg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.9.2.tgz",
-      "integrity": "sha512-pelyUy0uFzR7dsnleN8A+4yiNRIRQYFDufbOapP9qkgpEOSvJaD6zYOi3HDm4GdXD5jD0UFNEYMCbi2+Ed2zIg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.9.2.tgz",
-      "integrity": "sha512-qgrEyYbzXyqoIcl2iLXMvIv4PC1Z84O5TGCGKwGibblHAOpWIVQzkquDhty/aE9Ju1OSJiNZGtE9ISlJXB/PJA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-linux-arm64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.9.2.tgz",
-      "integrity": "sha512-FMl9EYCJSKCfJb8rrk+9mmi44SwDyNCMLvxMzG/va59D0BRItmm4EP9Zd2QoKnGawV6Bw4BAXIrNhSg9gWedxg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-linux-x64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.9.2.tgz",
-      "integrity": "sha512-+7wcz5+3HzOH8+PbNwOPuelTo6ik5jgrz8SFbd+JL6sZLap2pjpKWol5nJyNYNv90yRq1A6p8TrhFXCtVZujFA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-linux-x64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.9.2.tgz",
-      "integrity": "sha512-ims1jOq99zTvcwcUXKuD+WT36KHHVNTq9Fm663YzMMBO+5sqLleQtQkZgbh0BHJI25jvW9IrBCvuS1ZwKZ6kOA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-wasm32-wasi": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.9.2.tgz",
-      "integrity": "sha512-h/lWDJCYlsH3VUNWBCO2exite7VDPgjpOmaQgTQ6aNI5x8rR3NEkyXfmy/yWIev63tdMr9nD3sXw38QQp4ddIA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.9.2.tgz",
-      "integrity": "sha512-a3BkMcvW9sedSA1XlYvGEQSNQQrK4kUMULKTXmqboLjFbwI9v6flpDCiJyw2pXYs+1WT6XjTHvEyVsoGCVMRlQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.9.2.tgz",
-      "integrity": "sha512-k8xPkEOMJM3ic4UzvmvKELjPQsIFSo7mw1wx4tNrUN5mu5ANIhk1Fq0zXOcTbpIe7jHPsWaB5jYtBeeJ0h09iA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/jieba-win32-x64-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.9.2.tgz",
-      "integrity": "sha512-wIseuWUK+WdikhMFPLvr80D0I4wQJSdFsRIljiUhKwnNQESG20zIxSYE1qy7BNBd7s8fAn1BC6PGeg7S/2KliQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4281,15 +3952,6 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.8.1.tgz",
-      "integrity": "sha512-GSsTwyBl4pIzsxAY5wroZdyQKyhXk0d8PCRZtrSZ2WEB1cBdrp2EgGBwHOGCZtIIPun/DL3+AykCv+J6fyRH4Q==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/acorn": {
@@ -9834,11 +9496,6 @@
         "node": ">=16.x"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
-    },
     "node_modules/immer": {
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
@@ -10689,14 +10346,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
-      }
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -10885,21 +10534,6 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
-    },
-    "node_modules/lunr-languages": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz",
-      "integrity": "sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA=="
-    },
-    "node_modules/mark.js": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
-      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,6 @@
     "@docusaurus/plugin-google-gtag": "^3.1.1",
     "@docusaurus/plugin-google-tag-manager": "^3.1.1",
     "@docusaurus/preset-classic": "^3.1.1",
-    "@easyops-cn/docusaurus-search-local": "^0.40.1",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.0",
     "docusaurus-plugin-sass": "^0.2.5",


### PR DESCRIPTION
# test

> `test(() => void)`

`test` is a helper to assist you in such cases:

- Use the beforeEach and afterEach for each `test` performed
- Isolate or group your tests in the same file

```ts
import { test, beforeEach, afterEach } from 'poku';

const prepareService = () => true;
const resetService = () => true;

beforeEach(() => prepareService(), {
  assert: false,
});

afterEach(() => resetService(), {
  assert: false,
});

test(() => {
  // do anything you want
});

test(() => {
  // do anything you want
});
```

⚠️ Ensure you disabled the assert on **beforeEach** and **afterEach** options.

## By using promises

```ts
import { test, beforeEach, afterEach } from 'poku';

const prepareService = () =>
  new Promise((resolve) => resolve(true), {
    assert: false,
  });

const resetService = () =>
  new Promise((resolve) => resolve(true), {
    assert: false,
  });

beforeEach(async () => await prepareService());
afterEach(async () => await resetService());

await test(async () => {
  // do anything you want
});

await test(async () => {
  // do anything you want
});
```
