### PR TITLE
fix(test runner): ensure all logs when using `debug` option

### DIFF
--- a/src/services/run-test-file.ts
+++ b/src/services/run-test-file.ts
@@ -39,7 +39,7 @@ export const runTestFile = (
     const log = () => {
       const outputs = removeConsecutiveRepeats(
         showSuccess
-          ? output.split(/(\r\n|\r|\n)/)
+          ? [output]
           : output.split(/(\r\n|\r|\n)/).filter((current) => {
               if (current.includes('Exited with code')) return false;
               return (


### PR DESCRIPTION
When using the `debug` option and the first output from the console was a line, it didn't display the first assertion output.

This _PR_ fix it.