### PR TITLE
feat(deno): support for custom `deny` permissions

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -27,6 +27,7 @@ const killRange = getArg('kill-range');
 const killPID = getArg('kill-pid');
 const concurrency = Number(getArg('concurrency')) || undefined;
 const denoAllow = getSubArg('deno-allow');
+const denoDeny = getSubArg('deno-deny');
 
 // Multiple arguments with values or not
 // TODO (Custom Args)
@@ -82,6 +83,7 @@ if (hasArg('log-success'))
     // arguments: args.length > 0 ? args : undefined,
     deno: {
       allow: denoAllow,
+      deny: denoDeny,
     },
   });
 })();

--- a/src/helpers/runner.ts
+++ b/src/helpers/runner.ts
@@ -28,7 +28,13 @@ export const runner = (filename: string, configs?: Configs): string[] => {
           '--allow-net', // Create Service
         ];
 
-    return ['deno', 'run', ...denoAllow];
+    const denoDeny = configs?.deno?.deny
+      ? configs.deno.deny
+          .map((deny) => (deny ? `--deny-${deny}` : ''))
+          .filter((deny) => deny)
+      : [];
+
+    return ['deno', 'run', ...denoAllow, ...denoDeny];
   }
 
   // Node.js

--- a/test/unit/deno/deny.test.ts
+++ b/test/unit/deno/deny.test.ts
@@ -1,32 +1,18 @@
 import { assert, describe, test } from '../../../src/index.js';
 import { runner } from '../../../src/helpers/runner.js';
 
-describe('Deno Permissions (Allow)', { background: false, icon: '🔬' });
+describe('Deno Permissions (Deny)', { background: false, icon: '🔬' });
 
 test(() => {
   assert.deepStrictEqual(
     runner('', {
       platform: 'deno',
-    }),
-    [
-      'deno',
-      'run',
-      '--allow-read',
-      '--allow-env',
-      '--allow-run',
-      '--allow-net',
-    ],
-    'Default Permissions'
-  );
-
-  assert.deepStrictEqual(
-    runner('', {
-      platform: 'deno',
       deno: {
-        allow: ['read'],
+        allow: [],
+        deny: ['read'],
       },
     }),
-    ['deno', 'run', '--allow-read'],
+    ['deno', 'run', '--deny-read'],
     'Custom Permission'
   );
 
@@ -34,10 +20,11 @@ test(() => {
     runner('', {
       platform: 'deno',
       deno: {
-        allow: ['read', 'env'],
+        allow: [],
+        deny: ['read', 'env'],
       },
     }),
-    ['deno', 'run', '--allow-read', '--allow-env'],
+    ['deno', 'run', '--deny-read', '--deny-env'],
     'Custom Permissions'
   );
 
@@ -45,10 +32,11 @@ test(() => {
     runner('', {
       platform: 'deno',
       deno: {
-        allow: ['read=file.js', 'env'],
+        allow: [],
+        deny: ['read=file.js', 'env'],
       },
     }),
-    ['deno', 'run', '--allow-read=file.js', '--allow-env'],
+    ['deno', 'run', '--deny-read=file.js', '--deny-env'],
     'Custom Permissions per Files'
   );
 
@@ -56,10 +44,18 @@ test(() => {
     runner('', {
       platform: 'deno',
       deno: {
-        allow: [],
+        allow: ['read=file.js', 'net'],
+        deny: ['net=server.com', 'env'],
       },
     }),
-    ['deno', 'run'],
-    'No Permissions'
+    [
+      'deno',
+      'run',
+      '--allow-read=file.js',
+      '--allow-net',
+      '--deny-net=server.com',
+      '--deny-env',
+    ],
+    'Mixed Permissions'
   );
 });

--- a/website/docs/documentation/poku/options/deno.mdx
+++ b/website/docs/documentation/poku/options/deno.mdx
@@ -57,3 +57,39 @@ Clear all permissions:
 ```bash
 npx poku --deno-allow='' ./test
 ```
+
+## `deny`
+
+> `poku(targetPaths: string | string[], configs?: Configs)`
+>
+> `deny: string[]`
+
+Change permissions for **Deno**.
+
+### API (_in-code_)
+
+```ts
+poku(['...'], {
+  deno: {
+    deny: ['write', 'sys' /* ... */],
+  },
+});
+```
+
+```ts
+poku(['...'], {
+  deno: {
+    deny: ['env=HOME', 'write' /* ... */],
+  },
+});
+```
+
+### CLI
+
+```bash
+npx poku --deno-deny='write, sys' ./test
+```
+
+```bash
+npx poku --deno-deny='env=HOME, write' ./test
+```


### PR DESCRIPTION
# `deno`

## `deny`

> `deny: string[]`

Change permissions for **Deno**.

### API (_in-code_)

```ts
poku(['...'], {
  deno: {
    deny: ['write', 'sys' /* ... */],
  },
});
```

```ts
poku(['...'], {
  deno: {
    deny: ['env=HOME', 'write' /* ... */],
  },
});
```

### CLI

```bash
npx poku --deno-deny='write, sys' ./test
```

```bash
npx poku --deno-deny='env=HOME, write' ./test
```
