### PR TITLE
fix(cli): show external errors without requiring debugging

### DIFF
--- a/src/helpers/hr.ts
+++ b/src/helpers/hr.ts
@@ -4,7 +4,7 @@ import { EOL } from 'node:os';
 import process from 'node:process';
 
 export const hr = () => {
-  const line = '⎯'.repeat(process.stdout.columns - 10);
+  const line = '⎯'.repeat(process.stdout.columns - 10 || 40);
 
   console.log(`${EOL}\x1b[2m\x1b[90m${line}\x1b[0m${EOL}`);
 };

--- a/src/helpers/logs.ts
+++ b/src/helpers/logs.ts
@@ -10,20 +10,17 @@ export const isDebug = (configs?: Configs): boolean => Boolean(configs?.debug);
 
 export const printOutput = (options: {
   output: string;
-  runtime: string;
-  runtimeArguments: string[];
-  fileRelative: string;
+  result: boolean;
   configs?: Configs;
 }) => {
-  // const { output, runtime, runtimeArguments, fileRelative, configs } = options;
-  const { output, configs } = options;
+  const { output, result, configs } = options;
 
-  const showSuccess = isDebug(configs);
+  const debug = isDebug(configs);
   const pad = configs?.parallel ? '  ' : '    ';
   const splittedOutput = output.split(/\n/);
 
   const outputs = (
-    showSuccess
+    debug || !result
       ? splittedOutput
       : splittedOutput.filter((current) => {
           if (current.includes('Exited with code')) return false;
@@ -32,23 +29,6 @@ export const printOutput = (options: {
           );
         })
   ).filter((line) => line?.trim().length > 0);
-
-  // TODO: Create "strict" option
-  // if (!showSuccess && /error:/i.test(output) && !/error:/i.test(outputs.join()))
-  //   Object.assign(outputs, [
-  //     ...outputs,
-  //     format.bold(
-  //       format.fail(`✘ External Error ${format.dim(`› ${fileRelative}`)}`)
-  //     ),
-  //     format.dim('  For detailed diagnostics:'),
-  //     `${format.dim(`    CLI ›`)} rerun with the ${format.bold('--debug')} flag enabled.`,
-  //     `${format.dim(
-  //       `    API ›`
-  //     )} set the config option ${format.bold('debug')} to true.`,
-  //     `${format.dim('    RUN ›')} ${format.bold(
-  //       `${runtime === 'tsx' ? 'npx tsx' : runtime} ${runtimeArguments.slice(0, -1).join(' ')} ${fileRelative}`
-  //     )}`,
-  //   ]);
 
   if (outputs.length === 0) return;
 

--- a/src/helpers/parse-assertion.ts
+++ b/src/helpers/parse-assertion.ts
@@ -98,28 +98,33 @@ export const parseAssertion = async (
 
       console.log(
         isPoku
-          ? `${finalMessage} ${format.dim(format.fail(`› ${FILE}`))}`
-          : finalMessage
+          ? `${preIdentation}${finalMessage} ${format.dim(format.fail(`› ${FILE}`))}`
+          : `${preIdentation}${finalMessage}`
       );
 
-      file && console.log(`${format.dim('      File')} ${file}`);
-      console.log(`${format.dim('      Code')} ${code}`);
-      console.log(`${format.dim('  Operator')} ${operator}${EOL}`);
+      file &&
+        console.log(`${format.dim(`${preIdentation}      File`)} ${file}`);
+      console.log(`${format.dim(`${preIdentation}      Code`)} ${code}`);
+      console.log(
+        `${format.dim(`${preIdentation}  Operator`)} ${operator}${EOL}`
+      );
 
       if (!options?.hideDiff) {
         const splitActual = parseResultType(actual).split('\n');
         const splitExpected = parseResultType(expected).split('\n');
 
-        console.log(format.dim(`  ${options?.actual || 'Actual'}:`));
+        console.log(
+          format.dim(`${preIdentation}  ${options?.actual || 'Actual'}:`)
+        );
         splitActual.forEach((line) =>
-          console.log(`  ${format.bold(format.fail(line))}`)
+          console.log(`${preIdentation}  ${format.bold(format.fail(line))}`)
         );
 
         console.log(
-          `${EOL}  ${format.dim(`${options?.expected || 'Expected'}:`)}`
+          `${EOL}${preIdentation}  ${format.dim(`${options?.expected || 'Expected'}:`)}`
         );
         splitExpected.forEach((line) =>
-          console.log(`  ${format.bold(format.success(line))}`)
+          console.log(`${preIdentation}  ${format.bold(format.success(line))}`)
         );
       }
 

--- a/src/services/run-test-file.ts
+++ b/src/services/run-test-file.ts
@@ -62,18 +62,16 @@ export const runTestFile = (
     child.stderr.on('data', stdOut);
 
     child.on('close', async (code) => {
+      const result = code === 0;
+
       if (showLogs)
         printOutput({
           output,
-          runtime,
-          runtimeArguments,
-          fileRelative,
+          result,
           configs,
         });
 
       if (!(await afterEach(fileRelative, configs))) return false;
-
-      const result = code === 0;
 
       if (result) fileResults.success.push(fileRelative);
       else fileResults.fail.push(fileRelative);

--- a/test/e2e/background-process.test.ts
+++ b/test/e2e/background-process.test.ts
@@ -13,7 +13,7 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
   const runtime = getRuntime();
 
   await test(async () => {
-    describe('Start Service (Single Port)', { background: false, icon: '🔀' });
+    describe('Start Service (Single Port)', { icon: '🔀' });
 
     const server = await startService(`server-a.${ext}`, {
       startAfter: 'ready',
@@ -34,7 +34,7 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
   });
 
   await test(async () => {
-    describe('Start Script (Single Port)', { background: false, icon: '🔀' });
+    describe('Start Script (Single Port)', { icon: '🔀' });
 
     const server = await startScript(`start:${ext}`, {
       startAfter: 'ready',

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -7,7 +7,7 @@ const runtime = getRuntime();
 if (runtime === 'deno' && !isProduction) process.exit(0);
 
 test(async () => {
-  describe('Poku Test Runner: CLI', { background: false, icon: '🐷' });
+  describe('Poku Test Runner: CLI', { icon: '🐷' });
 
   const output = await executeCLI([
     ext === 'ts' || isProduction

--- a/test/e2e/exit-code.test.ts
+++ b/test/e2e/exit-code.test.ts
@@ -1,6 +1,6 @@
 import { poku, assert, describe, test } from '../../src/index.js';
 
-describe('Poku Runner Suite', { background: false, icon: '🐷' });
+describe('Poku Runner Suite', { icon: '🐷' });
 
 test(async () => {
   const code = await poku(['./fixtures/success', 'fixtures/fail'], {

--- a/test/integration/assert/assert-no-message.test.ts
+++ b/test/integration/assert/assert-no-message.test.ts
@@ -1,7 +1,7 @@
 import { nodeVersion } from '../../../src/helpers/get-runtime.js';
 import { assert, describe, test } from '../../../src/index.js';
 
-describe('Assert Suite (No Message)', { background: false, icon: '🔬' });
+describe('Assert Suite (No Message)', { icon: '🔬' });
 
 test(() => {
   assert(true);

--- a/test/integration/assert/assert-promise.test.ts
+++ b/test/integration/assert/assert-promise.test.ts
@@ -1,7 +1,7 @@
 import { nodeVersion } from '../../../src/helpers/get-runtime.js';
 import { assertPromise as assert, describe, test } from '../../../src/index.js';
 
-describe('Assert (Promise) Suite', { background: false, icon: '🔬' });
+describe('Assert (Promise) Suite', { icon: '🔬' });
 
 test(() => {
   assert(true, 'ok (default) with true');

--- a/test/integration/assert/assert.test.ts
+++ b/test/integration/assert/assert.test.ts
@@ -1,7 +1,7 @@
 import { nodeVersion } from '../../../src/helpers/get-runtime.js';
 import { assert, describe, test } from '../../../src/index.js';
 
-describe('Assert Suite', { background: false, icon: '🔬' });
+describe('Assert Suite', { icon: '🔬' });
 
 test(() => {
   assert(true, 'ok (default) with true');

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -1,6 +1,6 @@
 import * as index from '../../src/index.js';
 
-index.describe('Import Suite', { background: false, icon: '🔬' });
+index.describe('Import Suite', { icon: '🔬' });
 
 index.assert.ok(index.poku, 'Importing poku method');
 index.assert.ok(index.assert, 'Importing assert method');

--- a/test/unit/assert.result-type.test.ts
+++ b/test/unit/assert.result-type.test.ts
@@ -2,7 +2,8 @@ import { test, assert, describe } from '../../src/index.js';
 import { parseResultType } from '../../src/helpers/parse-assertion.js';
 import { nodeVersion } from '../../src/helpers/get-runtime.js';
 
-describe('Assert: Parse Result Type', { background: false, icon: '🔬' });
+describe('Assert: Parse Result Type', { icon: '🔬' });
+
 test(async () => {
   assert.deepStrictEqual(
     parseResultType(),

--- a/test/unit/deno/allow.test.ts
+++ b/test/unit/deno/allow.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, test } from '../../../src/index.js';
 import { runner } from '../../../src/helpers/runner.js';
 
-describe('Deno Permissions (Allow)', { background: false, icon: '🔬' });
+describe('Deno Permissions (Allow)', { icon: '🔬' });
 
 test(() => {
   assert.deepStrictEqual(

--- a/test/unit/deno/cjs.test.ts
+++ b/test/unit/deno/cjs.test.ts
@@ -8,7 +8,7 @@ const runtime = getRuntime();
 
 if (runtime !== 'deno') process.exit(0);
 
-describe('Deno Compatibility', { background: false, icon: '🦕' });
+describe('Deno Compatibility', { icon: '🦕' });
 
 const FILE = './fixtures/deno/require.cjs';
 const polyfillPath = './lib/polyfills/deno.mjs';

--- a/test/unit/deno/deny.test.ts
+++ b/test/unit/deno/deny.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, test } from '../../../src/index.js';
 import { runner } from '../../../src/helpers/runner.js';
 
-describe('Deno Permissions (Deny)', { background: false, icon: '🔬' });
+describe('Deno Permissions (Deny)', { icon: '🔬' });
 
 test(() => {
   assert.deepStrictEqual(

--- a/test/unit/run-test-file.test.ts
+++ b/test/unit/run-test-file.test.ts
@@ -6,7 +6,7 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
 const isProduction = process.env.NODE_ENV === 'production';
 const ext = getRuntime() === 'deno' ? 'ts' : isProduction ? 'js' : 'ts';
 
-describe('Service: runTestFile', { background: false, icon: '🔬' });
+describe('Service: runTestFile', { icon: '🔬' });
 
 test(async () => {
   const code = await runTestFile(`./fixtures/fail/exit.test.${ext}`, {

--- a/test/unit/run-tests.test.ts
+++ b/test/unit/run-tests.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, test } from '../../src/index.js';
 import { runTests } from '../../src/services/run-tests.js';
 
-describe('Service: runTests', { background: false, icon: '🔬' });
+describe('Service: runTests', { icon: '🔬' });
 
 test(async () => {
   const code = await runTests('./fixtures/fail', {


### PR DESCRIPTION
Now when an error occurs external to assert, it will be displayed without the need to use the `debug` option.

- The `debug` option continues to be useful for displaying logs external to **Poku**, such as `console.log`, etc.
