### PR TITLE
feat(test): support for Node.js familiar API usage

### DIFF
--- a/benchmark/test/poku/failure.spec.js
+++ b/benchmark/test/poku/failure.spec.js
@@ -1,6 +1,6 @@
 import { test, assert } from 'poku';
 import { sum } from '../../src/sum.js';
 
-test(() => {
-  assert.equal(sum(4, 4), 4, 'should add 4 + 4');
+test('should add 4 + 4', () => {
+  assert.equal(sum(4, 4), 4);
 });

--- a/benchmark/test/poku/success.spec.js
+++ b/benchmark/test/poku/success.spec.js
@@ -1,6 +1,6 @@
 import { test, assert } from 'poku';
 import { sum } from '../../src/sum.js';
 
-test(() => {
-  assert.equal(sum(2, 2), 4, 'should add 2 + 2');
+test('should add 2 + 2', () => {
+  assert.equal(sum(2, 2), 4);
 });

--- a/src/@types/describe.ts
+++ b/src/@types/describe.ts
@@ -1,0 +1,18 @@
+/* c8 ignore start */
+
+import { type backgroundColor } from '../helpers/format.js';
+
+export type DescribeOptions = {
+  background?: keyof typeof backgroundColor | boolean;
+  /**
+   * @default "☰"
+   */
+  icon?: string;
+  /** @deprecated */
+  pad?: boolean;
+  /**
+   * @default "grey"
+   */
+};
+
+/* c8 ignore stop */

--- a/src/configs/indentation.ts
+++ b/src/configs/indentation.ts
@@ -3,6 +3,8 @@
 export const indentation = {
   test: '  ',
   stdio: '      ',
+  describeCounter: 0,
+  testCounter: 0,
 };
 
 /* c8 ignore stop */

--- a/src/helpers/parse-assertion.ts
+++ b/src/helpers/parse-assertion.ts
@@ -6,7 +6,7 @@ import { format } from './format.js';
 import { hr } from './hr.js';
 import { findFile } from './find-file.js';
 import { each } from '../configs/each.js';
-import { describeCounter } from '../modules/describe.js';
+import { indentation } from '../configs/indentation.js';
 import { fromEntries, entries } from '../polyfills/object.js';
 import { nodeVersion } from './get-runtime.js';
 import { write } from './logs.js';
@@ -56,7 +56,7 @@ export const parseAssertion = async (
   const isPoku =
     typeof process.env?.FILE === 'string' && process.env?.FILE.length > 0;
   const FILE = process.env.FILE;
-  const preIdentation = describeCounter > 0 ? '  ' : '';
+  const preIdentation = indentation.describeCounter > 0 ? '  ' : '';
 
   try {
     if (typeof each.before.cb === 'function' && each.before.assert) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@
 export { poku } from './modules/poku.js';
 export { exit } from './modules/exit.js';
 export { assert } from './modules/assert.js';
-export { describe, log } from './modules/describe.js';
+export { describe } from './modules/describe.js';
+export { log } from './modules/log.js';
 export { assertPromise } from './modules/assert-promise.js';
 export { beforeEach, afterEach } from './modules/each.js';
 export { publicListFiles as listFiles } from './modules/list-files-sync.js';

--- a/src/modules/describe.ts
+++ b/src/modules/describe.ts
@@ -1,30 +1,8 @@
-/* c8 ignore start */
-
 import { format, backgroundColor } from '../helpers/format.js';
 import { write } from '../helpers/logs.js';
-
-export let describeCounter = 0;
-
-export type DescribeOptions = {
-  /** @deprecated */
-  pad?: boolean;
-  /**
-   * @default "grey"
-   */
-  background?: keyof typeof backgroundColor | boolean;
-  /**
-   * @default "☰"
-   */
-  icon?: string;
-};
-
-/**
- * By default **Poku** only shows outputs generated from itself.
- * This helper allows you to use an alternative to `console.log` with **Poku**.
- *
- * Need to debug? Just use the [`debug`](https://poku.io/docs/documentation/poku/options/debug) option from `poku`.
- */
-export const log = (message: string) => write(`\x1b[0m${message}\x1b[0m`);
+import { indentation } from '../configs/indentation.js';
+/* c8 ignore next */
+import type { DescribeOptions } from '../@types/describe.js';
 
 /**
  * On **Poku**, `describe` is just a pretty `console.log` to title your test suites in the terminal.
@@ -35,7 +13,7 @@ export const describe = (title: string, options?: DescribeOptions) => {
   const message = `${icon || '☰'} ${title}`;
   const noBackground = !background;
 
-  describeCounter++;
+  indentation.describeCounter++;
 
   if (noBackground) {
     write(`${format.bold(message)}`);
@@ -46,5 +24,3 @@ export const describe = (title: string, options?: DescribeOptions) => {
     `${format.bg(backgroundColor[typeof background === 'string' ? background : 'grey'], message)}`
   );
 };
-
-/* c8 ignore stop */

--- a/src/modules/describe.ts
+++ b/src/modules/describe.ts
@@ -15,6 +15,7 @@ export const describe = (title: string, options?: DescribeOptions) => {
 
   indentation.describeCounter++;
 
+  /* c8 ignore start */
   if (noBackground) {
     write(`${format.bold(message)}`);
     return;
@@ -23,4 +24,5 @@ export const describe = (title: string, options?: DescribeOptions) => {
   write(
     `${format.bg(backgroundColor[typeof background === 'string' ? background : 'grey'], message)}`
   );
+  /* c8 ignore stop */
 };

--- a/src/modules/log.ts
+++ b/src/modules/log.ts
@@ -1,0 +1,13 @@
+/* c8 ignore start */
+
+import { write } from '../helpers/logs.js';
+
+/**
+ * By default **Poku** only shows outputs generated from itself.
+ * This helper allows you to use an alternative to `console.log` with **Poku**.
+ *
+ * Need to debug? Just use the [`debug`](https://poku.io/docs/documentation/poku/options/debug) option from `poku`.
+ */
+export const log = (message: string) => write(`\x1b[0m${message}\x1b[0m`);
+
+/* c8 ignore stop */

--- a/src/modules/test.ts
+++ b/src/modules/test.ts
@@ -1,18 +1,39 @@
 /* c8 ignore next */
 import { each } from '../configs/each.js';
+import { describe } from './describe.js';
 
+export async function test(
+  message: string,
+  cb: () => Promise<unknown>
+): Promise<void>;
+export async function test(message: string, cb: () => unknown): Promise<void>;
 export async function test(cb: () => Promise<unknown>): Promise<void>;
 export function test(cb: () => unknown): void;
 export async function test(
-  cb: () => unknown | Promise<unknown>
+  ...args: [
+    string | (() => unknown | Promise<unknown>),
+    (() => unknown | Promise<unknown>)?,
+  ]
 ): Promise<void> {
+  let message: string | undefined;
+  let cb: () => unknown | Promise<unknown>;
+
   if (typeof each.before.cb === 'function' && each.before.test) {
     const beforeResult = each.before.cb();
+
     /* c8 ignore next */
     if (beforeResult instanceof Promise) await beforeResult;
   }
 
+  if (typeof args[0] === 'string') {
+    message = args[0];
+    cb = args[1] as () => unknown | Promise<unknown>;
+  } else cb = args[0] as () => unknown | Promise<unknown>;
+
+  if (message) describe(message, { icon: '›' });
+
   const resultCb = cb();
+
   /* c8 ignore next */
   if (resultCb instanceof Promise) await resultCb;
 

--- a/test/ci.test.ts
+++ b/test/ci.test.ts
@@ -1,4 +1,4 @@
-import { poku } from '../src/index.js';
+import { poku } from '../src/modules/poku.js';
 
 poku(['./test/compatibility'], {
   parallel: true,

--- a/test/e2e/background-process.test.ts
+++ b/test/e2e/background-process.test.ts
@@ -1,10 +1,7 @@
-import {
-  startService,
-  assert,
-  test,
-  describe,
-  startScript,
-} from '../../src/index.js';
+import { describe } from '../../src/modules/describe.js';
+import { test } from '../../src/modules/test.js';
+import { assert } from '../../src/modules/assert.js';
+import { startScript, startService } from '../../src/modules/create-service.js';
 import { legacyFetch } from '../helpers/legacy-fetch.test.js';
 import { ext, isProduction } from '../helpers/capture-cli.test.js';
 import { getRuntime } from '../../src/helpers/get-runtime.js';
@@ -57,7 +54,6 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
 
   await test(async () => {
     describe('Start Service (Multiple Ports)', {
-      background: false,
       icon: '🔀',
     });
 
@@ -81,7 +77,6 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
 
   await test(async () => {
     describe('Start Script (Multiple Ports)', {
-      background: false,
       icon: '🔀',
     });
 
@@ -107,7 +102,6 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
   if (runtime === 'node') {
     await test(async () => {
       describe('Start Service (No Ports)', {
-        background: false,
         icon: '🔀',
       });
 
@@ -133,7 +127,6 @@ import { getRuntime } from '../../src/helpers/get-runtime.js';
 
     await test(async () => {
       describe('Start Script (No Ports)', {
-        background: false,
         icon: '🔀',
       });
 

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -1,4 +1,6 @@
-import { assert, describe, test } from '../../src/index.js';
+import { describe } from '../../src/modules/describe.js';
+import { test } from '../../src/modules/test.js';
+import { assert } from '../../src/modules/assert.js';
 import { executeCLI, ext, isProduction } from '../helpers/capture-cli.test.js';
 import { getRuntime } from '../../src/helpers/get-runtime.js';
 

--- a/test/e2e/exit-code.test.ts
+++ b/test/e2e/exit-code.test.ts
@@ -1,4 +1,7 @@
-import { poku, assert, describe, test } from '../../src/index.js';
+import { describe } from '../../src/modules/describe.js';
+import { test } from '../../src/modules/test.js';
+import { poku } from '../../src/modules/poku.js';
+import { assert } from '../../src/modules/assert.js';
 
 describe('Poku Runner Suite', { icon: '🐷' });
 

--- a/test/integration/assert/assert-promise-no-message.test.ts
+++ b/test/integration/assert/assert-promise-no-message.test.ts
@@ -2,7 +2,6 @@ import { nodeVersion } from '../../../src/helpers/get-runtime.js';
 import { assertPromise as assert, describe, test } from '../../../src/index.js';
 
 describe('Assert Promise Suite (No Message)', {
-  background: false,
   icon: '🔬',
 });
 

--- a/test/integration/describe/describe.test.ts
+++ b/test/integration/describe/describe.test.ts
@@ -1,0 +1,2 @@
+// import { describe } from '../../../src/modules/describe.js';
+// import { test } from '../../../src/modules/test.js';

--- a/test/integration/each/each-promise.test.ts
+++ b/test/integration/each/each-promise.test.ts
@@ -1,13 +1,9 @@
-import {
-  describe,
-  assert,
-  beforeEach,
-  afterEach,
-  test,
-} from '../../../src/index.js';
+import { describe } from '../../../src/modules/describe.js';
+import { test } from '../../../src/modules/test.js';
+import { assert } from '../../../src/modules/assert.js';
+import { beforeEach, afterEach } from '../../../src/modules/each.js';
 
 describe('Asynchronous Before and After Each Suite', {
-  background: false,
   icon: '🔬',
 });
 

--- a/test/integration/each/each.test.ts
+++ b/test/integration/each/each.test.ts
@@ -1,13 +1,9 @@
-import {
-  describe,
-  assert,
-  beforeEach,
-  afterEach,
-  test,
-} from '../../../src/index.js';
+import { describe } from '../../../src/modules/describe.js';
+import { test } from '../../../src/modules/test.js';
+import { assert } from '../../../src/modules/assert.js';
+import { beforeEach, afterEach } from '../../../src/modules/each.js';
 
 describe('Before and After Each Suite', {
-  background: false,
   icon: '🔬',
 });
 

--- a/test/integration/test/test.test.ts
+++ b/test/integration/test/test.test.ts
@@ -1,11 +1,30 @@
-import { test } from '../../../src/index.js';
+import { describe, test } from '../../../src/index.js';
 
-(async () => {
+describe('Testing "test" method', {
+  icon: '🔬',
+});
+
+test(async () => {
+  test(() => {});
   test(() => true);
   test(() => false);
   test(() => undefined);
   test(() => new Promise((resolve) => resolve(undefined)));
   test(async () => await new Promise((resolve) => resolve(undefined)));
+
   await test(() => new Promise((resolve) => resolve(undefined)));
   await test(async () => await new Promise((resolve) => resolve(undefined)));
-})();
+});
+
+test(async () => {
+  test('', () => {});
+  test('', () => true);
+  test('', () => false);
+  test('', () => undefined);
+  test('', () => new Promise((resolve) => resolve(undefined)));
+  test('', async () => await new Promise((resolve) => resolve(undefined)));
+
+  await test('', () => new Promise((resolve) => resolve(undefined)));
+  await test('', async () =>
+    await new Promise((resolve) => resolve(undefined)));
+});

--- a/test/integration/test/test.test.ts
+++ b/test/integration/test/test.test.ts
@@ -1,4 +1,5 @@
-import { describe, test } from '../../../src/index.js';
+import { describe } from '../../../src/modules/describe.js';
+import { test } from '../../../src/modules/test.js';
 
 describe('Testing "test" method', {
   icon: '🔬',

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,4 +1,4 @@
-import { poku } from '../src/index.js';
+import { poku } from '../src/modules/poku.js';
 
 poku(['test/unit', 'test/integration', 'test/e2e'], {
   parallel: true,

--- a/test/unit/assert.result-type.test.ts
+++ b/test/unit/assert.result-type.test.ts
@@ -1,4 +1,6 @@
-import { test, assert, describe } from '../../src/index.js';
+import { describe } from '../../src/modules/describe.js';
+import { test } from '../../src/modules/test.js';
+import { assert } from '../../src/modules/assert.js';
 import { parseResultType } from '../../src/helpers/parse-assertion.js';
 import { nodeVersion } from '../../src/helpers/get-runtime.js';
 

--- a/test/unit/deno/allow.test.ts
+++ b/test/unit/deno/allow.test.ts
@@ -1,4 +1,6 @@
-import { assert, describe, test } from '../../../src/index.js';
+import { describe } from '../../../src/modules/describe.js';
+import { test } from '../../../src/modules/test.js';
+import { assert } from '../../../src/modules/assert.js';
 import { runner } from '../../../src/helpers/runner.js';
 
 describe('Deno Permissions (Allow)', { icon: '🔬' });

--- a/test/unit/deno/deny.test.ts
+++ b/test/unit/deno/deny.test.ts
@@ -1,4 +1,6 @@
-import { assert, describe, test } from '../../../src/index.js';
+import { describe } from '../../../src/modules/describe.js';
+import { test } from '../../../src/modules/test.js';
+import { assert } from '../../../src/modules/assert.js';
 import { runner } from '../../../src/helpers/runner.js';
 
 describe('Deno Permissions (Deny)', { icon: '🔬' });

--- a/test/unit/pad.test.ts
+++ b/test/unit/pad.test.ts
@@ -1,4 +1,4 @@
-import { assert } from '../../src/index.js';
+import { assert } from '../../src/modules/assert.js';
 import { padStart } from '../../src/polyfills/pad.js';
 
 assert.deepStrictEqual(padStart('', 0, ''), '');

--- a/test/unit/run-test-file.test.ts
+++ b/test/unit/run-test-file.test.ts
@@ -1,5 +1,7 @@
 import process from 'node:process';
-import { assert, describe, test } from '../../src/index.js';
+import { describe } from '../../src/modules/describe.js';
+import { test } from '../../src/modules/test.js';
+import { assert } from '../../src/modules/assert.js';
 import { runTestFile } from '../../src/services/run-test-file.js';
 import { getRuntime } from '../../src/helpers/get-runtime.js';
 

--- a/test/unit/run-tests.test.ts
+++ b/test/unit/run-tests.test.ts
@@ -1,4 +1,6 @@
-import { assert, describe, test } from '../../src/index.js';
+import { describe } from '../../src/modules/describe.js';
+import { test } from '../../src/modules/test.js';
+import { assert } from '../../src/modules/assert.js';
 import { runTests } from '../../src/services/run-tests.js';
 
 describe('Service: runTests', { icon: '🔬' });

--- a/website/docs/documentation/helpers/before-after-each/_category_.json
+++ b/website/docs/documentation/helpers/before-after-each/_category_.json
@@ -4,5 +4,5 @@
   "link": {
     "type": "generated-index"
   },
-  "position": 2
+  "position": 3
 }

--- a/website/docs/documentation/helpers/describe.mdx
+++ b/website/docs/documentation/helpers/describe.mdx
@@ -81,7 +81,6 @@ assert.ok(true, '2');
     import { assert, describe } from 'poku';
 
     describe('Needs to Succeed', {
-      background: false,
       icon: '🚀',
     });
 

--- a/website/docs/documentation/helpers/describe.mdx
+++ b/website/docs/documentation/helpers/describe.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 import { FAQ } from '@site/src/components/FAQ';

--- a/website/docs/documentation/helpers/log.mdx
+++ b/website/docs/documentation/helpers/log.mdx
@@ -1,7 +1,3 @@
----
-sidebar_position: 4
----
-
 # log
 
 Since by default **Poku** only shows outputs generated from itself, this helper allows you to use an alternative to `console.log` with **Poku** runner.

--- a/website/docs/documentation/helpers/test.mdx
+++ b/website/docs/documentation/helpers/test.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 ---
 
 # test
@@ -13,6 +13,8 @@ sidebar_position: 3
 - Run tests in the same file in parallel
 
 ## Basic Usage
+
+### Isolating scopes
 
 ```ts
 import { test, assert } from 'poku';
@@ -30,10 +32,39 @@ test(() => {
 });
 ```
 
-## By using promises
+### Grouping tests
 
 ```ts
 import { test, assert } from 'poku';
+
+test(() => {
+  assert.equal(1 + 1, 2, '1 + 1 should be 2');
+  assert.equal(2 + 2, 4, '2 + 2 should be 4');
+});
+```
+
+```ts
+import { test, assert } from 'poku';
+
+test('Sum tests', () => {
+  assert.equal(1 + 1, 2);
+  assert.equal(2 + 2, 4);
+});
+```
+
+```ts
+import { test, assert } from 'poku';
+
+test('Sum tests', () => {
+  assert.equal(1 + 1, 2, '1 + 1 should be 2');
+  assert.equal(2 + 2, 4, '2 + 2 should be 4');
+});
+```
+
+### Wating for Promises
+
+```ts
+import { test } from 'poku';
 
 await test(async () => {
   // do anything you want
@@ -44,10 +75,10 @@ await test(async () => {
 });
 ```
 
-## Running in Parallel
+### Running in parallel
 
 ```ts
-import { test, assert } from 'poku';
+import { test } from 'poku';
 
 test(async () => {
   // do anything you want
@@ -57,3 +88,27 @@ test(async () => {
   // do anything you want
 });
 ```
+
+### Wating for multiple promises
+
+```ts
+import { test } from 'poku';
+
+// do something before
+
+await Promise.all([
+  test(async () => {
+    // do anything you want
+  }),
+
+  test(async () => {
+    // do anything you want
+  }),
+]);
+
+// do something after
+```
+
+:::tip
+You can think on it as `beforeAll` and `afterAll`.
+:::


### PR DESCRIPTION
Now `test` module can be used as:

```ts
import { test, assert } from 'poku';

test(() => {
  assert.equal(1 + 1, 2, '1 + 1 should be 2');
});
```

```ts
import { test, assert } from 'poku';

test('Sum tests', () => {
  assert.equal(1 + 1, 2);
});
```

```ts
import { test, assert } from 'poku';

test('Sum tests', () => {
  assert.equal(1 + 1, 2, '1 + 1 should be 2');
});
```
