### PR TITLE
fix(logs): improve output for `test`, `describe` and `it`

### DIFF
--- a/src/configs/indentation.ts
+++ b/src/configs/indentation.ts
@@ -3,8 +3,9 @@
 export const indentation = {
   test: '  ',
   stdio: '      ',
-  describeCounter: 0,
-  testCounter: 0,
+  hasDescribe: false,
+  hasTest: false,
+  hasIt: false,
 };
 
 /* c8 ignore stop */

--- a/src/helpers/parse-assertion.ts
+++ b/src/helpers/parse-assertion.ts
@@ -5,7 +5,9 @@ import { EOL } from 'node:os';
 import { format } from './format.js';
 import { hr } from './hr.js';
 import { findFile } from './find-file.js';
+/* c8 ignore next */
 import { each } from '../configs/each.js';
+/* c8 ignore next */
 import { indentation } from '../configs/indentation.js';
 import { fromEntries, entries } from '../polyfills/object.js';
 import { nodeVersion } from './get-runtime.js';
@@ -56,7 +58,10 @@ export const parseAssertion = async (
   const isPoku =
     typeof process.env?.FILE === 'string' && process.env?.FILE.length > 0;
   const FILE = process.env.FILE;
-  const preIdentation = indentation.describeCounter > 0 ? '  ' : '';
+  let preIdentation = '';
+
+  if (indentation.hasDescribe || indentation.hasTest) preIdentation += '  ';
+  if (indentation.hasIt) preIdentation += '  ';
 
   try {
     if (typeof each.before.cb === 'function' && each.before.assert) {

--- a/src/modules/describe.ts
+++ b/src/modules/describe.ts
@@ -1,5 +1,6 @@
 import { format, backgroundColor } from '../helpers/format.js';
 import { write } from '../helpers/logs.js';
+/* c8 ignore next */
 import { indentation } from '../configs/indentation.js';
 /* c8 ignore next */
 import type { DescribeOptions } from '../@types/describe.js';
@@ -35,11 +36,11 @@ export async function describe(
 
   /* c8 ignore start */
   if (title) {
-    const { background, icon } = options || {};
-    const message = `${cb ? '›' : icon || '☰'} ${title || ''}`;
-    const noBackground = !background;
+    indentation.hasDescribe = true;
 
-    indentation.describeCounter++;
+    const { background, icon } = options || {};
+    const message = `${cb ? format.dim('◌') : icon || '☰'} ${format.bold(title) || ''}`;
+    const noBackground = !background;
 
     if (noBackground) write(`${format.bold(message)}`);
     else {
@@ -56,4 +57,11 @@ export async function describe(
 
   /* c8 ignore next */
   if (resultCb instanceof Promise) await resultCb;
+
+  /* c8 ignore start */
+  if (title) {
+    indentation.hasDescribe = false;
+    write(`${format.bold(format.success('●'))} ${format.bold(title)}`);
+  }
+  /* c8 ignore stop */
 }

--- a/src/modules/it.ts
+++ b/src/modules/it.ts
@@ -1,6 +1,9 @@
 /* c8 ignore next */
 import { each } from '../configs/each.js';
-import { describe } from './describe.js';
+/* c8 ignore next */
+import { indentation } from '../configs/indentation.js';
+import { format } from '../helpers/format.js';
+import { write } from '../helpers/logs.js';
 
 export async function it(
   message: string,
@@ -30,7 +33,14 @@ export async function it(
     cb = args[1] as () => unknown | Promise<unknown>;
   } else cb = args[0] as () => unknown | Promise<unknown>;
 
-  if (message) describe(message, { icon: '›' });
+  /* c8 ignore start */
+  if (message) {
+    indentation.hasIt = true;
+    write(
+      `${indentation.hasDescribe ? '  ' : ''}${format.dim('◌')} ${format.bold(format.italic(format.dim(message)))}`
+    );
+  }
+  /* c8 ignore end */
 
   const resultCb = cb();
 
@@ -42,4 +52,13 @@ export async function it(
     /* c8 ignore next */
     if (afterResult instanceof Promise) await afterResult;
   }
+
+  /* c8 ignore start */
+  if (message) {
+    indentation.hasIt = false;
+    write(
+      `${indentation.hasDescribe ? '  ' : ''}${format.bold(format.success('●'))} ${format.bold(format.italic(message))}`
+    );
+  }
+  /* c8 ignore stop */
 }

--- a/src/modules/test.ts
+++ b/src/modules/test.ts
@@ -1,6 +1,9 @@
 /* c8 ignore next */
 import { each } from '../configs/each.js';
-import { describe } from './describe.js';
+/* c8 ignore next */
+import { indentation } from '../configs/indentation.js';
+import { format } from '../helpers/format.js';
+import { write } from '../helpers/logs.js';
 
 export async function test(
   message: string,
@@ -30,7 +33,13 @@ export async function test(
     cb = args[1] as () => unknown | Promise<unknown>;
   } else cb = args[0] as () => unknown | Promise<unknown>;
 
-  if (message) describe(message, { icon: '›' });
+  /* c8 ignore start */
+  if (message) {
+    indentation.hasTest = true;
+
+    write(`${format.dim('◌')} ${format.bold(message)}`);
+  }
+  /* c8 ignore stop */
 
   const resultCb = cb();
 
@@ -42,4 +51,11 @@ export async function test(
     /* c8 ignore next */
     if (afterResult instanceof Promise) await afterResult;
   }
+
+  /* c8 ignore start */
+  if (message) {
+    indentation.hasTest = false;
+    write(`${format.bold(format.success('●'))} ${format.bold(message)}`);
+  }
+  /* c8 ignore stop */
 }


### PR DESCRIPTION
<img width="613" alt="Screenshot 2024-06-09 at 23 29 04" src="https://github.com/wellwelwel/poku/assets/46850407/045898dd-3157-4d1f-b988-66c414224a08">

---

<img width="613" alt="Screenshot 2024-06-09 at 23 33 21" src="https://github.com/wellwelwel/poku/assets/46850407/7f51864d-5519-4f4e-b119-0f43e53f7292">

