### PR TITLE
feat(processes): `waitForExpectedResult` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Enjoying **Poku**? Give him a star to show your support 🌟
 
 ## Why does Poku exist?
 
-**Poku** makes testing easy and takes on the testers' difficulties to _let you focus on your tests_:
+💡 **Poku** makes testing easy and brings the [native **JavaScript** syntax back to tests](https://poku.io/docs/philosophy), letting you to write tests intuitively — _just like in real **JavaScript** code_.
 
 <img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> No configurations<br />
 <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> Auto detect **ESM**, **CJS**, and **TypeScript** files<br />
@@ -53,8 +53,6 @@ Enjoying **Poku**? Give him a star to show your support 🌟
 <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> High **isolation** level per file<br />
 <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> **Performant** and **lightweight**<br />
 <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> Compatible with **coverage** tools
-
-> 💡 **Poku** brings the [essence of **JavaScript** back to testing](https://poku.io/docs/philosophy), allowing to use your knowledge to create tests intuitively.
 
 ---
 
@@ -180,6 +178,7 @@ deno run npm:poku
 - [**startService**](https://poku.io/docs/documentation/helpers/startService) _(run files in background)_
 - [**kill**](https://poku.io/docs/documentation/helpers/processes/kill) _(terminate ports, port ranges, and PIDs)_
 - [**waitForPort**](https://poku.io/docs/documentation/helpers/processes/wait-for-port) _(wait for specified ports to become active)_
+- [**waitForExpectedResult**](https://poku.io/docs/documentation/helpers/processes/wait-for-expected-result) _(retry until an expected result or times out)_
 - [**getPIDs**](https://poku.io/docs/documentation/helpers/processes/get-pids) _(debug processes IDs using ports and port ranges)_
 - _and much more_ 👇🏻
 
@@ -226,6 +225,8 @@ Please check the [**SECURITY.md**](https://github.com/wellwelwel/poku/blob/main/
 - [~**300x** lighter than **Vitest**](https://pkg-size.dev/vitest)
 - [~**170x** lighter than **Jest**](https://pkg-size.dev/jest)
 - [~**40x** lighter than **Mocha** + **Chai**](https://pkg-size.dev/mocha%20chai)
+
+> **Poku** size is highly significant in development to ensure cost-saving **CI** that require servers that charge for storage and usage.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Enjoying **Poku**? Give him a star to show your support 🌟
 
 <img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> No configurations<br />
 <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> Auto detect **ESM**, **CJS**, and **TypeScript** files<br />
-<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> Run the same test suite for [**Node.js**][node-version-url] _(6+)_, [**Bun**][bun-version-url] and [**Deno**][deno-version-url]<br />
+<span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> Run the same test suite for [**Node.js**][node-version-url], [**Bun**][bun-version-url] and [**Deno**][deno-version-url]<br />
 
 <img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> Easier and Less Verbose<br />
 <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><img width="16" height="16" alt="check" src="https://raw.githubusercontent.com/wellwelwel/poku/main/.github/assets/readme/check.svg"> [**Node.js**][node-version-url] familiar **API**<br />

--- a/src/@types/wait-for.ts
+++ b/src/@types/wait-for.ts
@@ -1,4 +1,4 @@
-export type WaitForPortOptions = {
+export type WaitForExpectedResultOptions = {
   /**
    * Retry interval in milliseconds
    *
@@ -24,6 +24,19 @@ export type WaitForPortOptions = {
    */
   delay?: number;
   /**
+   * Ensure strict comparisons.
+   *
+   * - For **Bun** users, this option isn't necessary.
+   *
+   * ---
+   *
+   * @default false
+   */
+  strict?: boolean;
+};
+
+export type WaitForPortOptions = {
+  /**
    * Host to check the port on.
    *
    * ---
@@ -31,4 +44,4 @@ export type WaitForPortOptions = {
    * @default "localhost"
    */
   host?: string;
-};
+} & Omit<WaitForExpectedResultOptions, 'strict'>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,30 @@
 /* c8 ignore start */
+
+// Essentials
 export { poku } from './modules/poku.js';
 export { assert } from './modules/assert.js';
+
+// Helpers
 export { test } from './modules/test.js';
 export { describe } from './modules/describe.js';
 export { it } from './modules/it.js';
-export { log } from './modules/log.js';
-export { assertPromise } from './modules/assert-promise.js';
 export { beforeEach, afterEach } from './modules/each.js';
-export { publicListFiles as listFiles } from './modules/list-files-sync.js';
-export { startService, startScript } from './modules/create-service.js';
-export { getPIDs, kill } from './modules/processes.js';
-export { sleep, waitForPort } from './modules/wait-for.js';
-export { exit } from './modules/exit.js';
 export { docker } from './modules/container.js';
+export { startScript, startService } from './modules/create-service.js';
+export {
+  waitForExpectedResult,
+  waitForPort,
+  sleep,
+} from './modules/wait-for.js';
+export { kill, getPIDs } from './modules/processes.js';
+export { exit } from './modules/exit.js';
+export { log } from './modules/log.js';
+export { publicListFiles as listFiles } from './modules/list-files-sync.js';
+export { assertPromise } from './modules/assert-promise.js';
+
+// Types
 export type { Code } from './@types/code.js';
 export type { Configs } from './@types/poku.js';
-export type { WaitForPortOptions } from './@types/processes.js';
-export type { Configs as ListFilesConfigs } from './@types/list-files.js';
 export type {
   DockerComposeConfigs,
   DockerfileConfigs,
@@ -25,4 +33,10 @@ export type {
   StartServiceOptions,
   StartScriptOptions,
 } from './@types/background-process.js';
+export type {
+  WaitForExpectedResultOptions,
+  WaitForPortOptions,
+} from './@types/wait-for.js';
+export type { Configs as ListFilesConfigs } from './@types/list-files.js';
+
 /* c8 ignore stop */

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -16,6 +16,10 @@ index.test('Import Suite', () => {
   index.assert.ok(index.log, 'Importing log helper');
   index.assert.ok(index.test, 'Importing test helper');
   index.assert.ok(index.sleep, 'Importing sleep helper');
+  index.assert.ok(
+    index.waitForExpectedResult,
+    'Importing waitForExpectedResult helper'
+  );
   index.assert.ok(index.waitForPort, 'Importing waitForPort helper');
   index.assert.ok(index.exit, 'Importing exit helper');
   index.assert.ok(index.listFiles, 'Importing listFiles helper');

--- a/test/integration/wait-for/wait-for-port.test.ts
+++ b/test/integration/wait-for/wait-for-port.test.ts
@@ -1,9 +1,8 @@
-import process from 'node:process';
 import { createServer, Server } from 'node:http';
-import { describe } from '../../../src/modules/describe.js';
+import { test } from '../../../src/modules/test.js';
 import { it } from '../../../src/modules/it.js';
 import { assert } from '../../../src/modules/assert.js';
-import { waitForPort, sleep } from '../../../src/modules/wait-for.js';
+import { waitForPort } from '../../../src/modules/wait-for.js';
 import { kill } from '../../../src/modules/processes.js';
 
 const startServer = (port: number): Promise<Server> =>
@@ -19,8 +18,10 @@ const startServer = (port: number): Promise<Server> =>
 const stopServer = (server: Server): Promise<void> =>
   new Promise((resolve) => server.close(() => resolve(undefined)));
 
-describe('Wait For Port', async () => {
-  await kill.range(8000, 8003);
+test('Wait For Port', async () => {
+  try {
+    await kill.range(8000, 8003);
+  } catch {}
 
   await Promise.all([
     it(async () => {
@@ -60,7 +61,7 @@ describe('Wait For Port', async () => {
       } catch (error) {
         assert.strictEqual(
           (error as Error).message,
-          `Timeout waiting for port ${port} to become active`,
+          `Timeout`,
           'Expected timeout for missing port'
         );
       }
@@ -81,19 +82,6 @@ describe('Wait For Port', async () => {
     }),
 
     it(async () => {
-      const startTime = Date.now();
-      const delay = 500;
-      await sleep(delay);
-      const elapsedTime = Date.now() - startTime;
-      const margin = 250;
-
-      assert.ok(
-        elapsedTime >= delay - margin && elapsedTime <= delay + margin,
-        `Expected sleep time to be around ${delay}ms (±${margin}ms), but was ${elapsedTime}ms`
-      );
-    }),
-
-    it(async () => {
       try {
         await waitForPort(NaN, { timeout: 2000 });
         assert.fail('Expected error for invalid port, but none was thrown');
@@ -106,12 +94,8 @@ describe('Wait For Port', async () => {
       }
     }),
   ]);
-});
 
-process.on('exit', () => {
-  process.on('exit', () => {
-    try {
-      kill.range(8000, 8003);
-    } catch {}
-  });
+  try {
+    await kill.range(8000, 8003);
+  } catch {}
 });

--- a/test/unit/wait-for/sleep.test.ts
+++ b/test/unit/wait-for/sleep.test.ts
@@ -1,0 +1,16 @@
+import { test } from '../../../src/modules/test.js';
+import { assert } from '../../../src/modules/assert.js';
+import { sleep } from '../../../src/modules/wait-for.js';
+
+test('Sleep "mini" helper', async () => {
+  const startTime = Date.now();
+  const delay = 500;
+  await sleep(delay);
+  const elapsedTime = Date.now() - startTime;
+  const margin = 250;
+
+  assert.ok(
+    elapsedTime >= delay - margin && elapsedTime <= delay + margin,
+    `Expected sleep time to be around ${delay}ms (±${margin}ms), but was ${elapsedTime}ms`
+  );
+});

--- a/test/unit/wait-for/wait-for-expected-result.test.ts
+++ b/test/unit/wait-for/wait-for-expected-result.test.ts
@@ -1,0 +1,188 @@
+import { test } from '../../../src/modules/test.js';
+import { assert } from '../../../src/modules/assert.js';
+import { waitForExpectedResult } from '../../../src/modules/wait-for.js';
+import { getRuntime } from '../../../src/helpers/get-runtime.js';
+
+test('Wait For Expected Result', async () => {
+  const runtime = getRuntime();
+
+  class SomeClass {}
+  function someFunc() {
+    true;
+  }
+  const SomeClass2 = class {};
+  const someFunc2 = () => true;
+
+  await Promise.all([
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => Promise.resolve(someFunc), someFunc, {
+          timeout: 100,
+        }),
+      'Function'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => Promise.resolve(someFunc2), someFunc2, {
+          timeout: 100,
+        }),
+      'Function (as const)'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(
+          () => Promise.resolve(() => true),
+          () => true,
+          {
+            timeout: 100,
+          }
+        ),
+      'Function (anonymous)'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => Symbol(), Symbol(), {
+          timeout: 100,
+        }),
+      'Symbol'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => Symbol.for('test'), Symbol.for('test'), {
+          timeout: 100,
+        }),
+      'Symbol.for'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => new Set([1, 2]), new Set([1, 1, 2, 2]), {
+          timeout: 100,
+        }),
+      'Set'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => new Map([[1, 2]]), new Map([[1, 2]]), {
+          timeout: 100,
+        }),
+      'Map'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => [false, 5], [false, 5], {
+          timeout: 100,
+        }),
+      'Array'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(
+          () => ({ a: true }),
+          { a: true },
+          {
+            timeout: 100,
+          }
+        ),
+      'Object'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => 'Hi', 'Hi', {
+          timeout: 100,
+        }),
+      'String'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => true, true, {
+          timeout: 100,
+        }),
+      'Boolean (true)'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => false, false, {
+          timeout: 100,
+        }),
+      'Boolean (false)'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => 3, 3, {
+          timeout: 100,
+        }),
+      'Number'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => {}, undefined, {
+          timeout: 100,
+        }),
+      'Undefined (Implict)'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => undefined, undefined, {
+          timeout: 100,
+        }),
+      'Undefined (Explict)'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => new Error(''), new Error(''), {
+          timeout: 100,
+        }),
+      'Error'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => SomeClass, SomeClass, {
+          timeout: 100,
+        }),
+      'Class'
+    ),
+
+    assert.doesNotReject(
+      () =>
+        waitForExpectedResult(() => SomeClass2, SomeClass2, {
+          timeout: 100,
+        }),
+      'Class (as const)'
+    ),
+
+    runtime === 'node' &&
+      assert.doesNotReject(
+        () =>
+          waitForExpectedResult(() => 1, true, {
+            timeout: 100,
+            strict: false,
+          }),
+        'No Strict Comparison'
+      ),
+
+    assert.rejects(
+      () =>
+        waitForExpectedResult(() => 1, true, {
+          timeout: 100,
+          strict: true,
+        }),
+      'Strict Comparison'
+    ),
+  ]);
+});

--- a/website/docs/comparing.mdx
+++ b/website/docs/comparing.mdx
@@ -1,3 +1,7 @@
+---
+tags: [Jest, Mocha, Chai, Vitest, AVA, TypeScript]
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/website/docs/documentation/assert/index.mdx
+++ b/website/docs/documentation/assert/index.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+tags: [assertions]
 ---
 
 import Tabs from '@theme/Tabs';

--- a/website/docs/documentation/helpers/before-after-each/in-code.mdx
+++ b/website/docs/documentation/helpers/before-after-each/in-code.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+tags: [hooks, setup, teardown]
 ---
 
 import Tabs from '@theme/Tabs';

--- a/website/docs/documentation/helpers/before-after-each/per-file.mdx
+++ b/website/docs/documentation/helpers/before-after-each/per-file.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+tags: [hooks, setup, teardown]
 ---
 
 import Tabs from '@theme/Tabs';

--- a/website/docs/documentation/helpers/containers.mdx
+++ b/website/docs/documentation/helpers/containers.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+tags: [containers]
 ---
 
 import { FAQ } from '@site/src/components/FAQ';
@@ -250,8 +251,10 @@ const result = await poku('./test/integration', {
   noExit: true,
 });
 
+// Stops the container
 await compose.down();
 
+// Shows the test results and ends the process with the test exit code.
 exit(result);
 ```
 

--- a/website/docs/documentation/helpers/describe.mdx
+++ b/website/docs/documentation/helpers/describe.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+tags: [boilerplate, tdd, bdd]
 ---
 
 import { FAQ } from '@site/src/components/FAQ';

--- a/website/docs/documentation/helpers/it.mdx
+++ b/website/docs/documentation/helpers/it.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+tags: [boilerplate, tdd, bdd]
 ---
 
 # 🧪 it

--- a/website/docs/documentation/helpers/processes/get-pids.mdx
+++ b/website/docs/documentation/helpers/processes/get-pids.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+tags: [processes, ports, debug]
 ---
 
 # Seaching PIDs

--- a/website/docs/documentation/helpers/processes/kill.mdx
+++ b/website/docs/documentation/helpers/processes/kill.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+tags: [processes, ports]
 ---
 
 # Killing Processes

--- a/website/docs/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/docs/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -1,0 +1,144 @@
+---
+sidebar_position: 3
+tags: [flakey, containers]
+---
+
+import { FAQ } from '@site/src/components/FAQ';
+
+# Waiting For Expected Results
+
+Similar to `assert`, but instead of returning an error when comparing, it will retry until success or timeout.
+
+> Wait for connections, external services to be ready, or a specific result from a method before starting the tests.
+
+## waitForExpectedResult
+
+```ts
+import { waitForExpectedResult } from 'poku';
+
+await waitForExpectedResult(() => true, true, {
+  delay: 0,
+  interval: 100,
+  timeout: 60000,
+  strict: false,
+});
+```
+
+<hr />
+
+<FAQ title='Options' >
+
+```ts
+export type WaitForExpectedResultOptions = {
+  /**
+   * Retry interval in milliseconds
+   *
+   * ---
+   *
+   * @default 100
+   */
+  interval?: number;
+  /**
+   * Timeout in milliseconds
+   *
+   * ---
+   *
+   * @default 60000
+   */
+  timeout?: number;
+  /**
+   * Delays both the start and end by the defined milliseconds.
+   *
+   * ---
+   *
+   * @default 0
+   */
+  delay?: number;
+  /**
+   * Ensure strict comparisons.
+   *
+   * - For **Bun** users, this option isn't necessary.
+   *
+   * ---
+   *
+   * @default false
+   */
+  strict?: boolean;
+};
+```
+
+</FAQ>
+
+<hr />
+
+## Examples
+
+Waiting for a Database Connection Returning `true`:
+
+```ts
+import { waitForExpectedResult } from 'poku';
+import { db } from './db.js';
+
+await waitForExpectedResult(() => db.connect(), true);
+// await waitForExpectedResult(async () => await db.connect(), true);
+```
+
+<hr />
+
+Waiting for a Database Connection doesn't Throw:
+
+```ts
+import { waitForExpectedResult } from 'poku';
+import { db } from './db.js';
+
+await waitForExpectedResult(async () => {
+  try {
+    await db.connect();
+    return true;
+  } catch {}
+}, true);
+```
+
+<hr />
+
+Waiting for a database connection from a container before to run the entire test suite and stops it on finishing:
+
+> **Poku** **API _(in-code)_** usage.
+
+```ts
+import { poku, docker, waitForExpectedResult, exit } from 'poku';
+import { db } from './db.js';
+
+// Load the docker-compose.yml
+const compose = docker.compose();
+
+// Starts the container
+await compose.up();
+
+// Waits for the database
+await waitForExpectedResult(async () => {
+  try {
+    await db.connect();
+    return true;
+  } catch {}
+}, true);
+
+// Starts the test suite
+const result = await poku('./test/integration', {
+  noExit: true,
+});
+
+// Stops the container
+await compose.down();
+
+// Shows the test results and ends the process with the test exit code.
+exit(result);
+```
+
+```sh
+node run.test.mjs
+```
+
+:::tip
+[See an example using **Dockerfile**.](/docs/documentation/helpers/containers#dockerfile)
+:::

--- a/website/docs/documentation/helpers/processes/wait-for-port.mdx
+++ b/website/docs/documentation/helpers/processes/wait-for-port.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+tags: [flakey, containers]
 ---
 
 import { FAQ } from '@site/src/components/FAQ';

--- a/website/docs/documentation/helpers/startScript.mdx
+++ b/website/docs/documentation/helpers/startScript.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+tags: [background, server, service, package.json, scripts]
 ---
 
 import Tabs from '@theme/Tabs';

--- a/website/docs/documentation/helpers/startService.mdx
+++ b/website/docs/documentation/helpers/startService.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+tags: [background, server, service]
 ---
 
 import Tabs from '@theme/Tabs';

--- a/website/docs/documentation/helpers/test.mdx
+++ b/website/docs/documentation/helpers/test.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+tags: [boilerplate, tdd, bdd]
 ---
 
 # 🧪 test

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -212,7 +212,7 @@ deno run npm:poku
 - [**startService**](/docs/documentation/helpers/startService) _(run files in background)_
 - [**kill**](/docs/documentation/helpers/processes/kill) _(terminate ports, port ranges, and PIDs)_
 - [**waitForPort**](/docs/documentation/helpers/processes/wait-for-port) _(wait for specified ports to become active)_
-- [**waitForExpectedResult**](/docs/documentation/helpers/processes/wait-for-port) _(wait for a function to return an expected result)_
+- [**waitForExpectedResult**](/docs/documentation/helpers/processes/wait-for-expected-result)_(retry until an expected result or times out)_
 - [**getPIDs**](/docs/documentation/helpers/processes/get-pids) _(debug processes IDs using ports and port ranges)_
 - _and much more_ 👇🏻
 

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -58,7 +58,7 @@ Enjoying **Poku**? [Consider giving him a star](https://github.com/wellwelwel/po
 
 <hr />
 
-## Why does Poku Exist?
+## Why does Poku exist?
 
 **Poku** can show you how simple testing can be 🌱
 
@@ -69,9 +69,7 @@ Enjoying **Poku**? [Consider giving him a star](https://github.com/wellwelwel/po
   </div>
   <div className='p'>
     <Success />
-    <span>
-      Run the same test suite for **Node.js** _(6+)_, **Bun** and **Deno**
-    </span>
+    <span>Run the same test suite for **Node.js**, **Bun** and **Deno**</span>
   </div>
   <div className='p'>
     <Success />
@@ -95,7 +93,7 @@ Enjoying **Poku**? [Consider giving him a star](https://github.com/wellwelwel/po
 
 <br />
 
-### Recommended Roadmap
+### Recommended Roadmap 🧑🏻‍🎓
 
 > 🔬 Start by seeing how to use [assert](/docs/documentation/assert). <br />
 > 🧪 Then learn how to use [poku](/docs/category/-poku) to run all your test files at once. <br />
@@ -214,6 +212,7 @@ deno run npm:poku
 - [**startService**](/docs/documentation/helpers/startService) _(run files in background)_
 - [**kill**](/docs/documentation/helpers/processes/kill) _(terminate ports, port ranges, and PIDs)_
 - [**waitForPort**](/docs/documentation/helpers/processes/wait-for-port) _(wait for specified ports to become active)_
+- [**waitForExpectedResult**](/docs/documentation/helpers/processes/wait-for-port) _(wait for a function to return an expected result)_
 - [**getPIDs**](/docs/documentation/helpers/processes/get-pids) _(debug processes IDs using ports and port ranges)_
 - _and much more_ 👇🏻
 


### PR DESCRIPTION
# Waiting For Expected Results

Similar to `assert`, but instead of returning an error when comparing, it will retry until success or timeout.

> Wait for connections, external services to be ready, or a specific result from a method before starting the tests.

## waitForExpectedResult

```ts
import { waitForExpectedResult } from 'poku';

await waitForExpectedResult(() => true, true, {
  delay: 0,
  interval: 100,
  timeout: 60000,
  strict: false,
});
```

---

## Examples

Waiting for a Database Connection Returning `true`:

```ts
import { waitForExpectedResult } from 'poku';
import { db } from './db.js';

await waitForExpectedResult(() => db.connect(), true);
// await waitForExpectedResult(async () => await db.connect(), true);
```

<hr />

Waiting for a Database Connection doesn't Throw:

```ts
import { waitForExpectedResult } from 'poku';
import { db } from './db.js';

await waitForExpectedResult(async () => {
  try {
    await db.connect();
    return true;
  } catch {}
}, true);
```

<hr />

Waiting for a database connection from a container before to run the entire test suite and stops it on finishing:

> **Poku** **API _(in-code)_** usage.

```ts
import { poku, docker, waitForExpectedResult, exit } from 'poku';
import { db } from './db.js';

// Load the docker-compose.yml
const compose = docker.compose();

// Starts the container
await compose.up();

// Waits for the database
await waitForExpectedResult(async () => {
  try {
    await db.connect();
    return true;
  } catch {}
}, true);

// Starts the test suite
const result = await poku('./test/integration', {
  noExit: true,
});

// Stops the container
await compose.down();

// Shows the test results and ends the process with the test exit code.
exit(result);
```

```sh
node run.test.mjs
```