### PR TITLE
feat(watch): reset and rerun all tests by entering `rs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "🐷 Poku makes testing easy for Node.js, Bun, Deno, and you at the same time.",
   "main": "./lib/modules/index.js",
   "license": "MIT",
+  "type": "commonjs",
   "bin": {
     "poku": "./lib/bin/index.js"
   },

--- a/src/modules/helpers/list-files.ts
+++ b/src/modules/helpers/list-files.ts
@@ -30,7 +30,6 @@ export const isFile = async (fullPath: string) =>
 export const escapeRegExp = (string: string) =>
   string.replace(regex.safeRegExp, '\\$&');
 
-/* c8 ignore next 3 */
 const envFilter = env.FILTER?.trim()
   ? new RegExp(escapeRegExp(env.FILTER), 'i')
   : undefined;
@@ -42,7 +41,6 @@ export const getAllFiles = async (
 ): Promise<Set<string>> => {
   const currentFiles = await readdir(sanitizePath(dirPath));
 
-  /* c8 ignore next 3 */
   const filter: RegExp = envFilter
     ? envFilter
     : configs?.filter instanceof RegExp

--- a/src/services/watch.ts
+++ b/src/services/watch.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { readdir, stat } from '../polyfills/fs.js';
 import { listFiles } from '../modules/helpers/list-files.js';
 
-class Watcher {
+export class Watcher {
   private rootDir: string;
   private files: string[] = [];
   private fileWatchers: Map<string, FSWatcher> = new Map();

--- a/test/c8.test.ts
+++ b/test/c8.test.ts
@@ -2,13 +2,11 @@ import { poku, test, describe, it, assert } from '../src/modules/index.js';
 import { isWindows } from '../src/parsers/get-runner.js';
 import { inspectCLI } from './helpers/capture-cli.test.js';
 
-console.log('\n😴 It will be really slow (press "Ctrl + C" twice to cancel)\n');
-
 test(async () => {
   await describe('CLI', async () => {
-    await it('Sequential (Unit)', async () => {
+    await it('Sequential (Just Touch)', async () => {
       const results = await inspectCLI(
-        'npx tsx src/bin/index.ts --platform=node --include=test/unit'
+        'npx tsx src/bin/index.ts --platform=node --include=test/integration/import.test.ts'
       );
 
       console.log(results.stdout);
@@ -17,9 +15,9 @@ test(async () => {
       assert.strictEqual(results.exitCode, 0, 'Passed');
     });
 
-    await it('Parallel (Unit)', async () => {
+    await it('Parallel (Just Touch)', async () => {
       const results = await inspectCLI(
-        'npx tsx src/bin/index.ts --platform=node --parallel --include=test/unit'
+        'npx tsx src/bin/index.ts --platform=node --parallel --include=test/integration/import.test.ts'
       );
 
       console.log(results.stdout);
@@ -28,11 +26,38 @@ test(async () => {
       assert.strictEqual(results.exitCode, 0, 'Passed');
     });
 
-    await it('Parallel + Unit + Options', async () => {
+    await it('Parallel (FILTER Env)', async () => {
+      const results = await inspectCLI(
+        'npx tsx src/bin/index.ts --platform=node --parallel --include=test/integration',
+        {
+          env: { ...process.env, FILTER: 'import' },
+        }
+      );
+
+      console.log(results.stdout);
+      console.log(results.stderr);
+
+      assert.strictEqual(results.exitCode, 0, 'Passed');
+    });
+
+    await it('Sequential + Options (Just Touch)', async () => {
       const results = await inspectCLI(
         isWindows
-          ? 'npx tsx src/bin/index.ts --parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" --include=test/unit --filter=".test.|.spec."'
-          : 'npx tsx src/bin/index.ts --parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 --include=test/unit --filter=.test.|.spec.'
+          ? 'npx tsx src/bin/index.ts --concurrency=4 --platform=node --fast-fail --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" --include=test/integration/import.test.ts --filter=".test.|.spec."'
+          : 'npx tsx src/bin/index.ts --concurrency=4 --platform=node --fast-fail --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 --include=test/integration/import.test.ts --filter=.test.|.spec.'
+      );
+
+      console.log(results.stdout);
+      console.log(results.stderr);
+
+      assert.strictEqual(results.exitCode, 0, 'Passed');
+    });
+
+    await it('Parallel + Options (Just Touch)', async () => {
+      const results = await inspectCLI(
+        isWindows
+          ? 'npx tsx src/bin/index.ts --parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" --include=test/integration/import.test.ts --filter=".test.|.spec."'
+          : 'npx tsx src/bin/index.ts --parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 --include=test/integration/import.test.ts --filter=.test.|.spec.'
       );
 
       console.log(results.stdout);
@@ -43,16 +68,7 @@ test(async () => {
   });
 
   await describe('API', async () => {
-    await it('Sequential (Unit)', async () => {
-      const exitCode = await poku(['test/unit'], {
-        platform: 'node',
-        noExit: true,
-      });
-
-      assert.strictEqual(exitCode, 0, 'Passed');
-    });
-
-    await it('Sequential (File)', async () => {
+    await it('Sequential (Single Input)', async () => {
       const exitCode = await poku('test/integration/import.test.ts', {
         platform: 'node',
         noExit: true,
@@ -61,7 +77,7 @@ test(async () => {
       assert.strictEqual(exitCode, 0, 'Passed');
     });
 
-    await it('Parallel (File)', async () => {
+    await it('Parallel (Single Input)', async () => {
       const exitCode = await poku('test/integration/import.test.ts', {
         platform: 'node',
         parallel: true,
@@ -71,17 +87,29 @@ test(async () => {
       assert.strictEqual(exitCode, 0, 'Passed');
     });
 
-    await it('Parallel (Unit)', async () => {
-      const exitCode = await poku(['test/unit'], {
+    await it('Unit (Exclude as Regex)', async () => {
+      const exitCode = await poku('test/unit', {
         platform: 'node',
         parallel: true,
+        exclude: /watch|wait|map-tests/,
         noExit: true,
       });
 
       assert.strictEqual(exitCode, 0, 'Passed');
     });
 
-    await it('Parallel + All + Options', async () => {
+    await it('Unit (Exclude as Array of Regex)', async () => {
+      const exitCode = await poku('test/unit', {
+        platform: 'node',
+        parallel: true,
+        exclude: [/watch/, /wait/, /map-tests/],
+        noExit: true,
+      });
+
+      assert.strictEqual(exitCode, 0, 'Passed');
+    });
+
+    await it('Parallel + Unit + Integration + E2E + Options', async () => {
       const exitCode = await poku(
         ['test/unit', 'test/integration', 'test/e2e'],
         {
@@ -89,7 +117,6 @@ test(async () => {
           parallel: true,
           debug: true,
           concurrency: 4,
-          exclude: [/import.test/],
           filter: /\.(test|spec)\./,
           failFast: true,
           noExit: true,

--- a/test/c8.test.ts
+++ b/test/c8.test.ts
@@ -91,7 +91,7 @@ test(async () => {
       const exitCode = await poku('test/unit', {
         platform: 'node',
         parallel: true,
-        exclude: /watch|wait|map-tests/,
+        exclude: /watch|map-tests/,
         noExit: true,
       });
 
@@ -102,7 +102,7 @@ test(async () => {
       const exitCode = await poku('test/unit', {
         platform: 'node',
         parallel: true,
-        exclude: [/watch/, /wait/, /map-tests/],
+        exclude: [/watch/, /map-tests/],
         noExit: true,
       });
 

--- a/website/docs/documentation/poku/options/watch.mdx
+++ b/website/docs/documentation/poku/options/watch.mdx
@@ -22,21 +22,33 @@ npx poku --watch --watch-interval=1500
 
 <hr />
 
+:::tip
+
+Quickly reset and rerun all tests by typing <kbd>rs</kbd> on the console, followed by <kbd>Enter</kbd>.
+
+- This will clean and repopulate all the directories and files to be watched.
+- It's not possible to use it while the tests are running.
+
+:::
+
+<hr />
+
+:::info
+
+If it's not possible to determine which test file depends on the changed source file, no test will be run.
+
+:::
+
+<hr />
+
 :::note
 
-Currently, the deep dependency search doesn't consider line-breaking imports, for example:
+❌ Dynamic paths are not supported:
 
 ```ts
-import {
-  moduleA,
-  moduleB,
-  moduleC,
-  moduleD,
-  moduleE,
-  moduleF,
-} from './some.js';
-```
+const dynamicPath = './some-file.js';
 
-- See [**#499**](https://github.com/wellwelwel/poku/issues/449).
+await import(dynamicPath);
+```
 
 :::


### PR DESCRIPTION
Quickly reset and rerun all tests by typing <kbd>rs</kbd> on the console, followed by <kbd>Enter</kbd>.

- This will clean and repopulate all the directories and files to be watched.
- It's not possible to use it while the tests are running.

---

> [!note]
>
> If it's not possible to determine which test file depends on the changed source file, no test will be run.