### PR TITLE
feat: add out-of-box support for `.env` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ deno run npm:poku
 
 ### Common Options
 
+- [**env**](https://poku.io/docs/documentation/helpers/env) _(process an environment file)_
 - [**watch**](https://poku.io/docs/documentation/poku/options/watch) _(watch for changes and re-run related test files)_
 - [**parallel**](https://poku.io/docs/documentation/poku/options/parallel) _(run tests in parallel)_
 - [**debug**](https://poku.io/docs/documentation/poku/options/debug) _(shows all logs)_

--- a/fixtures/.env.test
+++ b/fixtures/.env.test
@@ -1,0 +1,17 @@
+HOST="123.123.123.123"
+# USER0="user"
+USER1='#user' # main user
+USER2=support # TT1 # TT2
+PASS1="nmnm@!sdf&*#@'RBUY3efPZpsqufHdhgdfhU!Bi90q.Zm.b7.C-8fpOIUSH&%GN"
+PASS2='nmnm@!sdf&*#@"RBUY3efPZpsqufHdhgdfhU!Bi90q.Zm.b7.C-8fpOIUSH&%GN'
+PASS3=nmnm@!sdf*@RBUY3efPZpsqufHdhgdfhU!Bi90q.Zm.b7.C-8fpOIUSH%GN
+PORT1=8080
+PORT2=#8081
+PORT3=${MY_PORT} # undefined variable
+WHO_AM_I="I'm ${MY_VAR}"
+SPACED1 = yes
+SPACED2 = "yes"
+SPACED3 = 'yes'
+NO_VALUE1
+NO_VALUE2=
+NO_VALUE3 =

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -13,7 +13,7 @@ import { fileResults } from '../configs/files.js';
 import { platformIsValid } from '../parsers/get-runtime.js';
 import { format } from '../services/format.js';
 import { kill } from '../modules/helpers/kill.js';
-import { setEnv } from '../modules/helpers/env.js';
+import { envFile } from '../modules/helpers/env.js';
 import { mapTests, normalizePath } from '../services/map-tests.js';
 import { watch, type Watcher } from '../services/watch.js';
 import { onSigint, poku } from '../modules/essentials/poku.js';
@@ -82,9 +82,9 @@ if (killPID) {
 }
 
 if (hasEnvFile) {
-  const envFile = getArg('env-file');
+  const envFilePath = getArg('env-file');
 
-  tasks.push(setEnv(envFile));
+  tasks.push(envFile(envFilePath));
 }
 
 const options: Configs = {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -13,6 +13,7 @@ import { fileResults } from '../configs/files.js';
 import { platformIsValid } from '../parsers/get-runtime.js';
 import { format } from '../services/format.js';
 import { kill } from '../modules/helpers/kill.js';
+import { setEnv } from '../modules/helpers/env.js';
 import { mapTests, normalizePath } from '../services/map-tests.js';
 import { watch, type Watcher } from '../services/watch.js';
 import { onSigint, poku } from '../modules/essentials/poku.js';
@@ -51,6 +52,7 @@ const quiet = hasArg('quiet');
 const debug = hasArg('debug');
 const failFast = hasArg('fail-fast');
 const watchMode = hasArg('watch');
+const hasEnvFile = hasArg('env-file');
 
 const concurrency = parallel
   ? Number(getArg('concurrency')) || undefined
@@ -77,6 +79,12 @@ if (killRange) {
 if (killPID) {
   const PIDs = killPID.split(',').map(Number);
   tasks.push(kill.pid(PIDs));
+}
+
+if (hasEnvFile) {
+  const envFile = getArg('env-file');
+
+  tasks.push(setEnv(envFile));
 }
 
 const options: Configs = {

--- a/src/modules/helpers/env.ts
+++ b/src/modules/helpers/env.ts
@@ -12,7 +12,7 @@ const regex = {
 };
 
 /** Reads an environment file and sets the environment variables. */
-export const setEnv = async (filePath = '.env') => {
+export const envFile = async (filePath = '.env') => {
   /* c8 ignore stop */
   const mapEnv = new Map<string, string>();
   const env = await readFile(sanitizePath(filePath), 'utf8');

--- a/src/modules/helpers/env.ts
+++ b/src/modules/helpers/env.ts
@@ -1,0 +1,37 @@
+/* c8 ignore start */ // ?
+import { readFile } from '../../polyfills/fs.js';
+import { sanitizePath } from './list-files.js';
+import {
+  parseEnvLine,
+  removeComments,
+  resolveEnvVariables,
+} from '../../services/env.js';
+
+const regex = {
+  comment: /^\s*#/,
+};
+
+/** Reads an environment file and sets the environment variables. */
+export const setEnv = async (filePath = '.env') => {
+  /* c8 ignore stop */
+  const mapEnv = new Map<string, string>();
+  const env = await readFile(sanitizePath(filePath), 'utf8');
+  const lines = env
+    .split('\n')
+    .map((line) => removeComments(line.trim()))
+    .filter((line) => line.length > 0 && !regex.comment.test(line));
+
+  for (const line of lines) {
+    const parsedLine = parseEnvLine(line);
+
+    if (parsedLine) {
+      const { arg, value } = parsedLine;
+
+      mapEnv.set(arg, value ? resolveEnvVariables(value, process.env) : value);
+    }
+  }
+
+  for (const [arg, value] of mapEnv) {
+    process.env[arg] = value;
+  }
+};

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,6 +3,7 @@ export { assert } from './essentials/assert.js';
 export { test } from './helpers/test.js';
 export { describe } from './helpers/describe.js';
 export { it } from './helpers/it.js';
+export { setEnv } from './helpers/env.js';
 export { skip } from './helpers/skip.js';
 export { beforeEach, afterEach } from './helpers/each.js';
 export { docker } from './helpers/container.js';

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,7 +3,7 @@ export { assert } from './essentials/assert.js';
 export { test } from './helpers/test.js';
 export { describe } from './helpers/describe.js';
 export { it } from './helpers/it.js';
-export { setEnv } from './helpers/env.js';
+export { envFile } from './helpers/env.js';
 export { skip } from './helpers/skip.js';
 export { beforeEach, afterEach } from './helpers/each.js';
 export { docker } from './helpers/container.js';

--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -1,0 +1,72 @@
+/* c8 ignore next */ // ?
+export const removeComments = (input: string) => {
+  let output = '';
+  let quoteChar = '';
+  let inQuote = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (inQuote) {
+      output += char;
+
+      if (char === quoteChar && input[i - 1] !== '\\') {
+        inQuote = false;
+      }
+    } else if (char === '"' || char === "'") {
+      inQuote = true;
+      quoteChar = char;
+      output += char;
+    } else if (char === '#') {
+      break;
+    } else {
+      output += char;
+    }
+  }
+
+  return output.trim();
+};
+
+/* c8 ignore net */ // ?
+export const parseEnvLine = (line: string) => {
+  const index = line.indexOf('=');
+
+  if (index === -1) {
+    return null;
+  }
+
+  const arg = line.substring(0, index).trim();
+  const value = line
+    .substring(index + 1)
+    .trim()
+    .replace(/^['"]|['"]$/g, '');
+
+  return { arg, value };
+};
+
+/* c8 ignore next */ // ?
+export const resolveEnvVariables = (str: string, env: typeof process.env) => {
+  let result = '';
+  let i = 0;
+
+  while (i < str.length) {
+    if (str[i] === '$' && str[i + 1] === '{') {
+      i += 2;
+
+      let varName = '';
+
+      while (i < str.length && str[i] !== '}') {
+        varName += str[i];
+        i++;
+      }
+
+      i++;
+      result += env[varName] || '';
+    } else {
+      result += str[i];
+      i++;
+    }
+  }
+
+  return result;
+};

--- a/test/c8.test.ts
+++ b/test/c8.test.ts
@@ -1,3 +1,4 @@
+import { env } from 'node:process';
 import { poku, test, describe, it, assert } from '../src/modules/index.js';
 import { isWindows } from '../src/parsers/get-runner.js';
 import { inspectCLI } from './helpers/capture-cli.test.js';
@@ -58,6 +59,25 @@ test(async () => {
         isWindows
           ? 'npx tsx src/bin/index.ts --parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" --include=test/integration/import.test.ts --filter=".test.|.spec."'
           : 'npx tsx src/bin/index.ts --parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 --include=test/integration/import.test.ts --filter=.test.|.spec.'
+      );
+
+      console.log(results.stdout);
+      console.log(results.stderr);
+
+      assert.strictEqual(results.exitCode, 0, 'Passed');
+    });
+
+    await it('Parallel + Options (CLI Env Variables Propagation)', async () => {
+      const results = await inspectCLI(
+        isWindows
+          ? 'npx tsx src/bin/index.ts --include=test/integration/env --env-file="fixtures/.env.test"'
+          : 'npx tsx src/bin/index.ts --include=test/integration/env --env-file=fixtures/.env.test',
+        {
+          env: {
+            ...env,
+            MY_VAR: 'Poku',
+          },
+        }
       );
 
       console.log(results.stdout);

--- a/test/integration/env/set-env.test.ts
+++ b/test/integration/env/set-env.test.ts
@@ -1,0 +1,68 @@
+import process from 'node:process';
+import { test } from '../../../src/modules/helpers/test.js';
+import { skip } from '../../../src/modules/helpers/skip.js';
+import { assert } from '../../../src/modules/essentials/assert.js';
+
+if (process.env.My_VAR !== 'Poku') {
+  skip("Skip tests when MY_VAR is not set to 'Poku'");
+}
+
+test('Defining Variables', () => {
+  assert.strictEqual(process.env.HOST, '123.123.123.123', 'Basic');
+  assert.strictEqual(process.env.USER0, undefined, 'Comented Line');
+  assert.strictEqual(process.env.USER1, '#user', 'Using quoted #');
+  assert.strictEqual(
+    process.env.USER2,
+    'support',
+    'Comments after the variable'
+  );
+  assert.strictEqual(
+    process.env.PASS1,
+    "nmnm@!sdf&*#@'RBUY3efPZpsqufHdhgdfhU!Bi90q.Zm.b7.C-8fpOIUSH&%GN",
+    'Complex string double quoted'
+  );
+  assert.strictEqual(
+    process.env.PASS2,
+    'nmnm@!sdf&*#@"RBUY3efPZpsqufHdhgdfhU!Bi90q.Zm.b7.C-8fpOIUSH&%GN',
+    'Complex single double quoted'
+  );
+  assert.strictEqual(
+    process.env.PASS3,
+    'nmnm@!sdf*@RBUY3efPZpsqufHdhgdfhU!Bi90q.Zm.b7.C-8fpOIUSH%GN',
+    'Complex string no quoted'
+  );
+  assert.strictEqual(process.env.PORT1, '8080', 'Using a number');
+  assert.strictEqual(
+    process.env.PORT2,
+    '',
+    'Valid env with full commented value'
+  );
+  assert.strictEqual(process.env.PORT3, '', 'Undefined local variable');
+  assert.strictEqual(
+    process.env.WHO_AM_I,
+    "I'm Poku",
+    'Resolved Env Variables'
+  );
+  assert.strictEqual(
+    process.env.SPACED1,
+    'yes',
+    'Using space between env and value'
+  );
+  assert.strictEqual(
+    process.env.SPACED2,
+    'yes',
+    'Using space between env and value with double quotes'
+  );
+  assert.strictEqual(
+    process.env.SPACED3,
+    'yes',
+    'Using space between env and value with single quotes'
+  );
+  assert.strictEqual(
+    process.env.NO_VALUE1,
+    undefined,
+    'Undefined value (invalid)'
+  );
+  assert.strictEqual(process.env.NO_VALUE2, '', 'No value (valid)');
+  assert.strictEqual(process.env.NO_VALUE3, '', 'No value (valid with spaces)');
+});

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -4,7 +4,7 @@ index.test('Import Suite', () => {
   index.assert.ok(index.poku, 'Importing poku method');
   index.assert.ok(index.assert, 'Importing assert method');
 
-  index.assert.ok(index.setEnv, 'Importing setEnv method');
+  index.assert.ok(index.envFile, 'Importing envFile method');
   index.assert.ok(index.assertPromise, 'Importing assertPromise method');
   index.assert.ok(index.startService, 'Importing startService method');
   index.assert.ok(index.startScript, 'Importing startScript method');

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -4,6 +4,7 @@ index.test('Import Suite', () => {
   index.assert.ok(index.poku, 'Importing poku method');
   index.assert.ok(index.assert, 'Importing assert method');
 
+  index.assert.ok(index.setEnv, 'Importing setEnv method');
   index.assert.ok(index.assertPromise, 'Importing assertPromise method');
   index.assert.ok(index.startService, 'Importing startService method');
   index.assert.ok(index.startScript, 'Importing startScript method');

--- a/test/unit/env-services.test.ts
+++ b/test/unit/env-services.test.ts
@@ -1,0 +1,120 @@
+import { describe } from '../../src/modules/helpers/describe.js';
+import { it } from '../../src/modules/helpers/it.js';
+import { assert } from '../../src/modules/essentials/assert.js';
+import {
+  removeComments,
+  parseEnvLine,
+  resolveEnvVariables,
+} from '../../src/services/env.js';
+
+describe('removeComments', () => {
+  it('should remove comments outside of quotes', () => {
+    assert.strictEqual(removeComments('value # this is a comment'), 'value');
+    assert.strictEqual(
+      removeComments('"value" # this is a comment'),
+      '"value"'
+    );
+    assert.strictEqual(
+      removeComments('value "quoted # not a comment" # this is a comment'),
+      'value "quoted # not a comment"'
+    );
+    assert.strictEqual(
+      removeComments("value 'quoted # not a comment' # this is a comment"),
+      "value 'quoted # not a comment'"
+    );
+  });
+
+  it('should handle empty input', () => {
+    assert.strictEqual(removeComments(''), '');
+  });
+
+  it('should handle input without comments', () => {
+    assert.strictEqual(removeComments('value'), 'value');
+  });
+
+  it('should handle escaped quotes', () => {
+    assert.strictEqual(
+      removeComments(
+        '"value with an escaped quote \\" still inside" # comment'
+      ),
+      '"value with an escaped quote \\" still inside"'
+    );
+    assert.strictEqual(
+      removeComments(
+        "'value with an escaped quote \\' still inside' # comment"
+      ),
+      "'value with an escaped quote \\' still inside'"
+    );
+  });
+
+  it('should remove comments after variable declaration', () => {
+    assert.strictEqual(removeComments('MY_ENV=SOME #test'), 'MY_ENV=SOME');
+  });
+});
+
+describe('parseEnvLine', () => {
+  it('should parse a valid env line', () => {
+    assert.deepStrictEqual(parseEnvLine('KEY=value'), {
+      arg: 'KEY',
+      value: 'value',
+    });
+    assert.deepStrictEqual(parseEnvLine('KEY="value"'), {
+      arg: 'KEY',
+      value: 'value',
+    });
+    assert.deepStrictEqual(parseEnvLine("KEY='value'"), {
+      arg: 'KEY',
+      value: 'value',
+    });
+  });
+
+  it('should return null for invalid env line', () => {
+    assert.strictEqual(parseEnvLine('invalidline'), null);
+    assert.strictEqual(parseEnvLine('KEY'), null);
+  });
+
+  it('should handle spaces around the equal sign', () => {
+    assert.deepStrictEqual(parseEnvLine('KEY = value'), {
+      arg: 'KEY',
+      value: 'value',
+    });
+    assert.deepStrictEqual(parseEnvLine('  KEY=value  '), {
+      arg: 'KEY',
+      value: 'value',
+    });
+  });
+});
+
+describe('resolveEnvVariables', () => {
+  it('should resolve environment variables', () => {
+    const env = { MY_VAR: 'resolvedValue' };
+    assert.strictEqual(
+      resolveEnvVariables('value is ${MY_VAR}', env),
+      'value is resolvedValue'
+    );
+    assert.strictEqual(
+      resolveEnvVariables('${MY_VAR} is set', env),
+      'resolvedValue is set'
+    );
+  });
+
+  it('should handle missing environment variables', () => {
+    const env = { MY_VAR: 'resolvedValue' };
+    assert.strictEqual(
+      resolveEnvVariables('value is ${UNKNOWN_VAR}', env),
+      'value is '
+    );
+    assert.strictEqual(
+      resolveEnvVariables('${UNKNOWN_VAR} is set', env),
+      ' is set'
+    );
+  });
+
+  it('should handle input without environment variables', () => {
+    const env = { MY_VAR: 'resolvedValue' };
+    assert.strictEqual(
+      resolveEnvVariables('no variables here', env),
+      'no variables here'
+    );
+  });
+});

--- a/website/docs/documentation/helpers/env.mdx
+++ b/website/docs/documentation/helpers/env.mdx
@@ -1,0 +1,86 @@
+---
+sidebar_position: 4
+tags: [env, .env, dotenv]
+---
+
+# ⚙️ env
+
+Reads an environment file and sets the environment variables.
+
+## CLI
+
+Loading the `.env` by default:
+
+```sh
+npx poku --env-file
+```
+
+Loading a custom `.env`:
+
+```sh
+npx poku --env-file='path/to/my/.env'
+```
+
+<hr />
+
+## API (in-code)
+
+> You can set a `.env` file directly in a specif test or by using it globally.
+
+Loading the `.env` by default:
+
+```ts
+import { setEnv } from 'poku';
+
+await setEnv();
+```
+
+Loading a custom `.env`:
+
+```ts
+import { setEnv, poku } from 'poku';
+
+await setEnv('path/to/my/.env');
+
+await poku('./');
+```
+
+<hr />
+
+:::note
+It's not possible to retrieve files from directories above the current process, e.g. `../.env`.
+:::
+
+<hr />
+
+:::danger
+**Poku** is made entirely for testing purposes, please don't use this functionality outside of testing.
+:::
+
+<hr />
+
+## Real Examples
+
+- `.env.test`
+
+```sh
+HOST='localhost'
+PORT='8080'
+```
+
+Then, in a test file, you can use it as:
+
+```js
+import { assert } from 'poku';
+
+const host = process.env.HOST;
+const port = process.env.PORT;
+
+// Your tests come here
+```
+
+Then, run your tests
+
+```sh
+npx poku --env-file='.env.test'
+```

--- a/website/docs/documentation/helpers/env.mdx
+++ b/website/docs/documentation/helpers/env.mdx
@@ -30,17 +30,17 @@ npx poku --env-file='path/to/my/.env'
 Loading the `.env` by default:
 
 ```ts
-import { setEnv } from 'poku';
+import { envFile } from 'poku';
 
-await setEnv();
+await envFile();
 ```
 
 Loading a custom `.env`:
 
 ```ts
-import { setEnv, poku } from 'poku';
+import { envFile, poku } from 'poku';
 
-await setEnv('path/to/my/.env');
+await envFile('path/to/my/.env');
 
 await poku('./');
 ```

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -176,6 +176,7 @@ deno run npm:poku
 
 ### Common Options
 
+- [**env**](/docs/documentation/helpers/env) _(process an environment file)_
 - [**watch**](/docs/documentation/poku/options/watch) _(watch for changes and re-run related test files)_
 - [**parallel**](/docs/documentation/poku/options/parallel) _(run tests in parallel)_
 - [**debug**](/docs/documentation/poku/options/debug) _(shows all logs)_

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -143,9 +143,7 @@ const Home = () => {
               </section>
               <section>
                 <Heading as='h2' className='float'>
-                  <span>
-                    Intermediary
-                  </span>
+                  <span>Intermediary</span>
                   <MidLevel />
                 </Heading>
                 <div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -144,7 +144,7 @@ const Home = () => {
               <section>
                 <Heading as='h2' className='float'>
                   <span>
-                    Mid Level <em>(Intermediary)</em>
+                    Intermediary
                   </span>
                   <MidLevel />
                 </Heading>
@@ -183,7 +183,7 @@ const Home = () => {
               <section>
                 <Heading as='h2' className='float'>
                   <span>
-                    Library <em>and</em> Package Maintainer
+                    Library <em>/</em> Package Maintainer
                   </span>
                   <Maintainer />
                 </Heading>
@@ -193,10 +193,6 @@ const Home = () => {
                     <strong>Bun</strong>, and <strong>Deno</strong> (including
                     different versions) to ensure that your package is
                     compatible with the platforms you want.
-                  </p>
-                  <p>
-                    There's no problem if your project is <strong>CJS</strong>,{' '}
-                    <strong>ESM</strong> or <strong>TypeScript</strong>.
                   </p>
                 </div>
                 <Link to='/docs/tutorials/cross-platform'>


### PR DESCRIPTION
Support read an environment file and sets the environment variables.

## CLI

Loading the `.env` by default:

```sh
npx poku --env-file
```

Loading a custom `.env`:

```sh
npx poku --env-file='path/to/my/.env'
```

<hr />

## API (in-code)

> You can set a `.env` file directly in a specif test or by using it globally.

Loading the `.env` by default:

```ts
import { envFile } from 'poku';

await envFile();
```

Loading a custom `.env`:

```ts
import { envFile, poku } from 'poku';

await envFile('path/to/my/.env');

await poku('./');
```

<hr />

> [!note]
>
> It's not possible to retrieve files from directories above the current process, e.g. `../.env`.


<hr />

> [!important]
>
> **Poku** is made entirely for testing purposes, please don't use this functionality outside of testing.


<hr />

## Real Examples

- `.env.test`

```sh
HOST='localhost'
PORT='8080'
```

Then, in a test file, you can use it as:

```js
import { assert } from 'poku';

const host = process.env.HOST;
const port = process.env.PORT;

// Your tests come here
```

Then, run your tests

```sh
npx poku --env-file='.env.test'
```
