### PR TITLE
fix: fix typings of `it()` and `test()` helpers

### DIFF
--- a/src/modules/helpers/it.ts
+++ b/src/modules/helpers/it.ts
@@ -9,7 +9,7 @@ export async function it(
   message: string,
   cb: () => Promise<unknown>
 ): Promise<void>;
-export async function it(message: string, cb: () => unknown): Promise<void>;
+export function it(message: string, cb: () => unknown): void;
 export async function it(cb: () => Promise<unknown>): Promise<void>;
 export function it(cb: () => unknown): void;
 /* c8 ignore next */ // ?

--- a/src/modules/helpers/test.ts
+++ b/src/modules/helpers/test.ts
@@ -9,7 +9,7 @@ export async function test(
   message: string,
   cb: () => Promise<unknown>
 ): Promise<void>;
-export async function test(message: string, cb: () => unknown): Promise<void>;
+export function test(message: string, cb: () => unknown): void;
 export async function test(cb: () => Promise<unknown>): Promise<void>;
 export function test(cb: () => unknown): void;
 /* c8 ignore next */ // ?


### PR DESCRIPTION
Fixes #579

Here is a fix for minor typings issue as suggested in https://github.com/wellwelwel/poku/issues/579#issuecomment-2243268342