### PR TITLE
docs: fix few typos

### DIFF
--- a/website/docs/documentation/helpers/it.mdx
+++ b/website/docs/documentation/helpers/it.mdx
@@ -31,7 +31,7 @@ describe('Calc suite', () => {
 });
 ```
 
-### Wating for Promises
+### Waiting for promises
 
 ```ts
 import { describe, it } from 'poku';
@@ -63,7 +63,7 @@ describe(() => {
 });
 ```
 
-### Wating for multiple promises
+### Waiting for multiple promises
 
 ```ts
 import { describe, it } from 'poku';

--- a/website/docs/documentation/helpers/test.mdx
+++ b/website/docs/documentation/helpers/test.mdx
@@ -62,7 +62,7 @@ test('Sum tests', () => {
 });
 ```
 
-### Wating for Promises
+### Waiting for promises
 
 ```ts
 import { test } from 'poku';
@@ -90,7 +90,7 @@ test(async () => {
 });
 ```
 
-### Wating for multiple promises
+### Waiting for multiple promises
 
 ```ts
 import { test } from 'poku';


### PR DESCRIPTION
Here is a fix for a few minor typos in docs.