### PR TITLE
ci: improve project coverage rate transparency

### DIFF
--- a/src/modules/essentials/poku.ts
+++ b/src/modules/essentials/poku.ts
@@ -36,7 +36,6 @@ export async function poku(
 
   const start = process.hrtime();
   const prepareDirs = Array.prototype.concat(targetPaths);
-  /* c8 ignore next */ // TODO: Allow users to pass cwd for monorepo improvements
   const dirs = prepareDirs.length > 0 ? prepareDirs : ['.'];
   const showLogs = !isQuiet(configs);
 
@@ -45,7 +44,6 @@ export async function poku(
     for (const dir of dirs) {
       const result = await runTests(dir, configs);
 
-      /* c8 ignore next 6 */
       if (!result) {
         code = 1;
         if (configs?.failFast) {
@@ -70,7 +68,6 @@ export async function poku(
   // Parallel
   if (showLogs) {
     Write.hr();
-    /* c8 ignore next */ // ?
     Write.log(`${format('Running the Test Suite in Parallel').bold()}\n`);
   }
 
@@ -78,7 +75,6 @@ export async function poku(
     const promises = dirs.map(async (dir) => {
       const result = await runTestsParallel(dir, configs);
 
-      /* c8 ignore next 3 */
       if (!result && configs?.failFast) {
         throw new Error('quiet');
       }
@@ -88,11 +84,9 @@ export async function poku(
 
     const concurrency = await Promise.all(promises);
 
-    /* c8 ignore next 3 */
     if (concurrency.some((result) => !result)) {
       code = 1;
     }
-    /* c8 ignore next */
   } catch {
   } finally {
     const end = process.hrtime(start);
@@ -114,7 +108,6 @@ export async function poku(
     );
   }
 
-  /* c8 ignore start */
   if (showLogs && fileResults.fail.size > 0) {
     Write.log(
       Array.from(fileResults.fail)
@@ -125,7 +118,6 @@ export async function poku(
         .join('\n')
     );
   }
-  /* c8 ignore stop */
 
   if (configs?.noExit) {
     return code;

--- a/src/modules/helpers/it.ts
+++ b/src/modules/helpers/it.ts
@@ -28,7 +28,6 @@ export async function it(
   if (typeof each.before.cb === 'function') {
     const beforeResult = each.before.cb();
 
-    /* c8 ignore next 3 */
     if (beforeResult instanceof Promise) {
       await beforeResult;
     }
@@ -56,7 +55,6 @@ export async function it(
   const start = hrtime();
   const resultCb = cb();
 
-  /* c8 ignore next 3 */
   if (resultCb instanceof Promise) {
     await resultCb;
   }
@@ -66,7 +64,6 @@ export async function it(
   if (typeof each.after.cb === 'function') {
     const afterResult = each.after.cb();
 
-    /* c8 ignore next 3 */
     if (afterResult instanceof Promise) {
       await afterResult;
     }

--- a/src/modules/helpers/test.ts
+++ b/src/modules/helpers/test.ts
@@ -28,7 +28,6 @@ export async function test(
   if (typeof each.before.cb === 'function') {
     const beforeResult = each.before.cb();
 
-    /* c8 ignore next 3 */
     if (beforeResult instanceof Promise) {
       await beforeResult;
     }
@@ -56,7 +55,6 @@ export async function test(
   const start = hrtime();
   const resultCb = cb();
 
-  /* c8 ignore next 3 */
   if (resultCb instanceof Promise) {
     await resultCb;
   }
@@ -66,7 +64,6 @@ export async function test(
   if (typeof each.after.cb === 'function') {
     const afterResult = each.after.cb();
 
-    /* c8 ignore next 3 */
     if (afterResult instanceof Promise) {
       await afterResult;
     }

--- a/src/parsers/assert.ts
+++ b/src/parsers/assert.ts
@@ -22,7 +22,7 @@ export const parseResultType = (type?: unknown): string => {
       return Array.from(value).map(recurse);
     }
 
-    /* c8 ignore start */ // Vary versions
+    /* c8 ignore start */
     if (value instanceof Map) {
       return recurse(
         !nodeVersion || nodeVersion >= 12

--- a/src/parsers/output.ts
+++ b/src/parsers/output.ts
@@ -11,7 +11,6 @@ const regex = {
 export const isQuiet = (configs?: Configs): boolean =>
   typeof configs?.quiet === 'boolean' && Boolean(configs?.quiet);
 
-/* c8 ignore next */
 export const isDebug = (configs?: Configs): boolean => Boolean(configs?.debug);
 
 /* c8 ignore next */ // ?

--- a/src/services/assert.ts
+++ b/src/services/assert.ts
@@ -34,7 +34,6 @@ export const processAssert = async (
   try {
     const cbResult = cb();
 
-    /* c8 ignore next 3 */
     if (cbResult instanceof Promise) {
       await cbResult;
     }

--- a/src/services/each.ts
+++ b/src/services/each.ts
@@ -9,7 +9,6 @@ const eachCore = async (
   fileRelative: string,
   configs?: Configs
 ): Promise<boolean> => {
-  /* c8 ignore next 3 */
   if (typeof configs?.[type] !== 'function') {
     return true;
   }

--- a/src/services/map-tests.ts
+++ b/src/services/map-tests.ts
@@ -85,7 +85,6 @@ const collectTestFiles = async (
       return [testPath];
     }
 
-    /* c8 ignore next */
     return [];
   });
 
@@ -94,8 +93,7 @@ const collectTestFiles = async (
   return new Set(nestedTestFiles.flat());
 };
 
-/* c8 ignore start */
-const processDeepImports = async (
+export const processDeepImports = async (
   srcFile: string,
   testFile: string,
   intersectedSrcFiles: Set<string>
@@ -118,10 +116,8 @@ const processDeepImports = async (
     await processDeepImports(deepImport, testFile, intersectedSrcFiles);
   }
 };
-/* c8 ignore stop */
 
-/* c8 ignore start */
-const createImportMap = async (
+export const createImportMap = async (
   allTestFiles: Set<string>,
   allSrcFiles: Set<string>
 ) => {
@@ -154,7 +150,6 @@ const createImportMap = async (
     })
   );
 };
-/* c8 ignore stop */
 
 /* c8 ignore next */ // ?
 export const mapTests = async (

--- a/src/services/run-test-file.ts
+++ b/src/services/run-test-file.ts
@@ -50,7 +50,6 @@ export const runTestFile = async (
   const start = hrtime();
   let end: ReturnType<typeof hrtime>;
 
-  /* c8 ignore next 3 */
   if (!(await beforeEach(fileRelative, configs))) {
     return false;
   }
@@ -83,7 +82,6 @@ export const runTestFile = async (
         mappedOutputs && Write.log(mappedOutputs.join('\n'));
       }
 
-      /* c8 ignore next 4 */
       if (!(await afterEach(fileRelative, configs))) {
         resolve(false);
         return;

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -116,14 +116,12 @@ export const runTestsParallel = async (
   try {
     for (const fileGroup of filesByConcurrency) {
       const promises = fileGroup.map(async (filePath) => {
-        /* c8 ignore next 3 */
         if (configs?.failFast && results.fail > 0) {
           return;
         }
 
         const testPassed = await runTestFile(filePath, configs);
 
-        /* c8 ignore start */
         if (!testPassed) {
           ++results.fail;
 
@@ -135,7 +133,6 @@ export const runTestsParallel = async (
 
           return false;
         }
-        /* c8 ignore false */
 
         ++results.success;
         return true;

--- a/src/services/watch.ts
+++ b/src/services/watch.ts
@@ -18,7 +18,6 @@ export class Watcher {
   }
 
   private watchFile(filePath: string) {
-    /* c8 ignore next 3 */
     if (this.fileWatchers.has(filePath)) {
       return;
     }
@@ -51,7 +50,6 @@ export class Watcher {
   }
 
   private async watchDirectory(dir: string) {
-    /* c8 ignore next 3 */
     if (this.dirWatchers.has(dir)) {
       return;
     }


### PR DESCRIPTION
In this _PR_, I have revised all the `c8 ignore` comments that do not comply with what is documented in [CONTRIBUTING.md#coverage](https://github.com/wellwelwel/poku/blob/main/CONTRIBUTING.md#%EF%B8%8F-coverage) to ensure more transparent coverage in order to #578.

---

> [!NOTE]
> 
> There are still comments that can be removed by migrating to `monocart-coverage-reports`, but I'll focus my priority on issue #580 first.

---

> cc: @mrazauskas 