### PR TITLE
fix(Windows): ensure configuration file loading (`js` and `cjs`)

### DIFF
--- a/fixtures/config-files/custom-cjs-file/custom.cjs
+++ b/fixtures/config-files/custom-cjs-file/custom.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  debug: true,
+};

--- a/src/parsers/options.ts
+++ b/src/parsers/options.ts
@@ -25,8 +25,7 @@ export const getConfigs = async (
 
     try {
       if (filePath.endsWith('.js') || filePath.endsWith('.cjs')) {
-        /* c8 ignore next */ // ?
-        return (await import(normalize(filePath))) as ConfigFile;
+        return require(`file://${normalize(filePath)}`);
       }
 
       const configsFile = await readFile(filePath, 'utf-8');

--- a/test/e2e/config-files.test.ts
+++ b/test/e2e/config-files.test.ts
@@ -74,4 +74,30 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
     assert(/PASS › 1/.test(output.stdout), 'CLI needs to pass 1');
     assert(/debug/.test(output.stdout), 'CLI needs to pass able "debug"');
   });
+
+  await it('Custom (CJS)', async () => {
+    const output = await inspectCLI(
+      'npx tsx ../../../src/bin/index.ts --config=custom.cjs',
+      {
+        cwd: 'fixtures/config-files/custom-cjs-file',
+      }
+    );
+
+    assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
+    assert(/PASS › 1/.test(output.stdout), 'CLI needs to pass 1');
+    assert(/debug/.test(output.stdout), 'CLI needs to pass able "debug"');
+  });
+
+  await it('Missing (JS)', async () => {
+    const output = await inspectCLI(
+      'npx tsx ../../../src/bin/index.ts --config=missing.js',
+      {
+        cwd: 'fixtures/config-files/custom-js-file',
+      }
+    );
+
+    assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
+    assert(/PASS › 1/.test(output.stdout), 'CLI needs to fail 1');
+    assert(!/debug/.test(output.stdout), 'CLI needs to pass able "debug"');
+  });
 });


### PR DESCRIPTION
Currently, using the configuration files as `.js` and `.cjs` doesn't load settings on **Windows**.
