### PR TITLE
refactor: change the assertion error message placeholder

### DIFF
--- a/src/services/assert.ts
+++ b/src/services/assert.ts
@@ -50,8 +50,8 @@ export const processAssert = async (
   } catch (error) {
     if (error instanceof AssertionError) {
       const { code, actual, expected, operator } = error;
-      const absoultePath = findFile(error).replace(regexFile, '');
-      const file = path.relative(path.resolve(cwd), absoultePath);
+      const absolutePath = findFile(error).replace(regexFile, '');
+      const file = path.relative(path.resolve(cwd), absolutePath);
 
       let message = '';
 
@@ -66,7 +66,7 @@ export const processAssert = async (
       const finalMessage =
         message?.trim().length > 0
           ? format(`✘ ${message}`).fail().bold()
-          : format('✘ No Message').fail().bold();
+          : format('✘ Assertion Error').fail().bold();
 
       Write.log(
         isPoku


### PR DESCRIPTION
I would like to change the assertion error message placeholder to "Assertion Error".

Currently it prints as "No Message". I saw it several times and each time the first though was: my code did not return message that was expected. In other words, it felt like an assertion got an empty string instead of expected value and reported that no message was received.

It took me a moment that this is just a heading. And that it says that the assertion simply failed. So I though to suggested changing this placeholder into generic "Assertion Error". If that’s acceptable.