### PR TITLE
fix: always use half of available parallelism

### DIFF
--- a/src/polyfills/cpus.ts
+++ b/src/polyfills/cpus.ts
@@ -5,5 +5,5 @@ import {
 
 export const availableParallelism = (): number =>
   typeof nodeAvailableParallelism === 'function'
-    ? Math.floor(nodeAvailableParallelism() / 2)
+    ? nodeAvailableParallelism()
     : (cpus()?.length ?? 1);

--- a/src/polyfills/cpus.ts
+++ b/src/polyfills/cpus.ts
@@ -6,4 +6,4 @@ import {
 export const availableParallelism = (): number =>
   typeof nodeAvailableParallelism === 'function'
     ? nodeAvailableParallelism()
-    : (cpus()?.length ?? 1);
+    : (cpus()?.length ?? 0);

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -97,7 +97,8 @@ export const runTestsParallel = async (
     ? [sanitizePath(dir)]
     : await listFiles(testDir, configs);
   const filesByConcurrency: string[][] = [];
-  const concurrencyLimit = configs?.concurrency ?? availableParallelism();
+  const concurrencyLimit =
+    configs?.concurrency ?? Math.floor(availableParallelism() / 2);
   const concurrencyResults: (boolean | undefined)[][] = [];
   const showLogs = !isQuiet(configs);
 

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -98,7 +98,7 @@ export const runTestsParallel = async (
     : await listFiles(testDir, configs);
   const filesByConcurrency: string[][] = [];
   const concurrencyLimit =
-    configs?.concurrency ?? Math.floor(availableParallelism() / 2);
+    configs?.concurrency ?? Math.max(Math.floor(availableParallelism() / 2), 1);
   const concurrencyResults: (boolean | undefined)[][] = [];
   const showLogs = !isQuiet(configs);
 

--- a/website/docs/documentation/poku/options/concurrency.mdx
+++ b/website/docs/documentation/poku/options/concurrency.mdx
@@ -5,7 +5,8 @@ sidebar_position: 8
 # `concurrency`
 
 When using `parallel` option, use `concurrency` to limit the number of tests running concurrently.<br />
-The default value is `0` (no limit).
+The default value is half of the available cores. When available, the `os.availableParallelism()` method is used. Otherwise Poku looks at the `os.cpus().length` or sets the value to `1`.<br />
+To allow unlimited parallelism set the value to `0`.
 
 ## CLI
 

--- a/website/docs/documentation/poku/options/concurrency.mdx
+++ b/website/docs/documentation/poku/options/concurrency.mdx
@@ -5,7 +5,8 @@ sidebar_position: 8
 # `concurrency`
 
 When using `parallel` option, use `concurrency` to limit the number of tests running concurrently.<br />
-The default value is half of the available cores. When available, the `os.availableParallelism()` method is used. Otherwise Poku looks at the `os.cpus().length` or falls back to the value of `0` (no limit).
+The default value is half of the available cores. When available, the `os.availableParallelism()` method is used. Otherwise Poku looks at the `os.cpus().length` or sets the value to `1`.<br />
+To allow unlimited parallelism set the value to `0`.
 
 ## CLI
 

--- a/website/docs/documentation/poku/options/concurrency.mdx
+++ b/website/docs/documentation/poku/options/concurrency.mdx
@@ -5,8 +5,7 @@ sidebar_position: 8
 # `concurrency`
 
 When using `parallel` option, use `concurrency` to limit the number of tests running concurrently.<br />
-The default value is half of the available cores. When available, the `os.availableParallelism()` method is used. Otherwise Poku looks at the `os.cpus().length` or sets the value to `1`.<br />
-To allow unlimited parallelism set the value to `0`.
+The default value is half of the available cores. When available, the `os.availableParallelism()` method is used. Otherwise Poku looks at the `os.cpus().length` or falls back to the value of `0` (no limit).
 
 ## CLI
 


### PR DESCRIPTION
Not sure if that was intentional. While calculating `concurrency`, current logic is takes half of `availableParallelism()`, but `os.cpus().length` is not divided by `2`. So I though to fix this.

Also documentation needs an adjustment.