### PR TITLE
refactor: restructure `it` for future method extensions

### DIFF
--- a/fixtures/no-runner/basic-logs.test.ts
+++ b/fixtures/no-runner/basic-logs.test.ts
@@ -1,7 +1,7 @@
 import { assert } from '../../src/modules/essentials/assert.js';
 import { test } from '../../src/modules/helpers/test.js';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 
 assert(true, 'Should emit a basic assetion log');
 

--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -1,17 +1,17 @@
 import { hrtime, env } from 'node:process';
-import { each } from '../../configs/each.js';
-import { indentation } from '../../configs/indentation.js';
-import { format } from '../../services/format.js';
-import { Write } from '../../services/write.js';
+import { each } from '../../../configs/each.js';
+import { indentation } from '../../../configs/indentation.js';
+import { format } from '../../../services/format.js';
+import { Write } from '../../../services/write.js';
 
-export async function it(
+async function itCore(
   message: string,
   cb: () => Promise<unknown>
 ): Promise<void>;
-export function it(message: string, cb: () => unknown): void;
-export async function it(cb: () => Promise<unknown>): Promise<void>;
-export function it(cb: () => unknown): void;
-export async function it(
+function itCore(message: string, cb: () => unknown): void;
+async function itCore(cb: () => Promise<unknown>): Promise<void>;
+function itCore(cb: () => unknown): void;
+async function itCore(
   ...args: [
     string | (() => unknown | Promise<unknown>),
     (() => unknown | Promise<unknown>)?,
@@ -88,3 +88,5 @@ export async function it(
     throw error;
   }
 }
+
+export const it = Object.assign(itCore, {});

--- a/src/modules/helpers/test.ts
+++ b/src/modules/helpers/test.ts
@@ -1,3 +1,3 @@
-import { it } from './it.js';
+import { it } from './it/core.js';
 
 export const test = it;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -5,7 +5,7 @@ export { assert } from './essentials/assert.js';
 export { strict } from './essentials/strict.js';
 export { test } from './helpers/test.js';
 export { describe } from './helpers/describe.js';
-export { it } from './helpers/it.js';
+export { it } from './helpers/it/core.js';
 export { envFile } from './helpers/env.js';
 export { skip } from './helpers/skip.js';
 export { beforeEach, afterEach } from './helpers/each.js';

--- a/test/e2e/background-process.test.ts
+++ b/test/e2e/background-process.test.ts
@@ -1,6 +1,6 @@
 import { test } from '../../src/modules/helpers/test.js';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import {
   startScript,

--- a/test/e2e/basic-logs.test.ts
+++ b/test/e2e/basic-logs.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { inspectCLI, isProduction } from '../helpers/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';

--- a/test/e2e/before-and-after-each.test.ts
+++ b/test/e2e/before-and-after-each.test.ts
@@ -1,6 +1,6 @@
 import { test } from '../../src/modules/helpers/test.js';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { poku } from '../../src/modules/essentials/poku.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { isProduction } from '../helpers/capture-cli.test.js';

--- a/test/e2e/config-files.test.ts
+++ b/test/e2e/config-files.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { inspectCLI, isProduction } from '../helpers/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';

--- a/test/e2e/each-api/failure.test.ts
+++ b/test/e2e/each-api/failure.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { inspectCLI, isProduction } from '../../helpers/capture-cli.test.js';
 import { skip } from '../../../src/modules/helpers/skip.js';

--- a/test/e2e/each-api/order.test.ts
+++ b/test/e2e/each-api/order.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { inspectCLI, isProduction } from '../../helpers/capture-cli.test.js';
 import { skip } from '../../../src/modules/helpers/skip.js';

--- a/test/e2e/exit-code.test.ts
+++ b/test/e2e/exit-code.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { poku } from '../../src/modules/essentials/poku.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 

--- a/test/e2e/fail-fast.test.ts
+++ b/test/e2e/fail-fast.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { inspectCLI, isProduction } from '../helpers/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';

--- a/test/e2e/failure.test.ts
+++ b/test/e2e/failure.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { inspectCLI, isProduction } from '../helpers/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';

--- a/test/e2e/runners.test.ts
+++ b/test/e2e/runners.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { isProduction, inspectCLI } from '../helpers/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';

--- a/test/e2e/watch.test.ts
+++ b/test/e2e/watch.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { watchCLI } from '../helpers/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';

--- a/test/integration/assert/assert-no-message.test.ts
+++ b/test/integration/assert/assert-no-message.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { nodeVersion } from '../../../src/parsers/get-runtime.js';
 

--- a/test/integration/assert/assert.test.ts
+++ b/test/integration/assert/assert.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { nodeVersion } from '../../../src/parsers/get-runtime.js';
 

--- a/test/integration/containers/test-docker-compose.test.ts
+++ b/test/integration/containers/test-docker-compose.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { docker } from '../../../src/modules/helpers/container.js';
 import { legacyFetch } from '../../helpers/legacy-fetch.test.js';

--- a/test/integration/containers/test-dockerfile.test.ts
+++ b/test/integration/containers/test-dockerfile.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { docker } from '../../../src/modules/helpers/container.js';
 import { waitForPort } from '../../../src/modules/helpers/wait-for.js';

--- a/test/integration/it/each/each-options-promise.test.ts
+++ b/test/integration/it/each/each-options-promise.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../../../src/modules/helpers/describe.js';
-import { it } from '../../../../src/modules/helpers/it.js';
+import { it } from '../../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../../src/modules/essentials/assert.js';
 import { beforeEach, afterEach } from '../../../../src/modules/helpers/each.js';
 

--- a/test/integration/it/each/each-options.test.ts
+++ b/test/integration/it/each/each-options.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../../../src/modules/helpers/describe.js';
-import { it } from '../../../../src/modules/helpers/it.js';
+import { it } from '../../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../../src/modules/essentials/assert.js';
 import { beforeEach, afterEach } from '../../../../src/modules/helpers/each.js';
 

--- a/test/integration/it/it.test.ts
+++ b/test/integration/it/it.test.ts
@@ -1,6 +1,6 @@
 import { test } from '../../../src/modules/helpers/test.js';
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 
 test('Testing "it" method', () => {
   describe(async () => {

--- a/test/integration/strict/assert-no-message.test.ts
+++ b/test/integration/strict/assert-no-message.test.ts
@@ -6,7 +6,7 @@ if (nodeVersion && nodeVersion < 16) {
 }
 
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { strict as assert } from '../../../src/modules/essentials/strict.js';
 
 describe('Strict Suite (No Message)', () => {

--- a/test/integration/strict/assert.test.ts
+++ b/test/integration/strict/assert.test.ts
@@ -6,7 +6,7 @@ if (nodeVersion && nodeVersion < 16) {
 }
 
 import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { strict as assert } from '../../../src/modules/essentials/strict.js';
 
 describe('Strict Suite', async () => {

--- a/test/integration/wait-for/wait-for-port.test.ts
+++ b/test/integration/wait-for/wait-for-port.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import { test } from '../../../src/modules/helpers/test.js';
-import { it } from '../../../src/modules/helpers/it.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 import { waitForPort } from '../../../src/modules/helpers/wait-for.js';
 import { kill } from '../../../src/modules/helpers/kill.js';

--- a/test/unit/args.test.ts
+++ b/test/unit/args.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import {
   getArg,

--- a/test/unit/env-services.test.ts
+++ b/test/unit/env-services.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import {
   removeComments,

--- a/test/unit/logs.test.ts
+++ b/test/unit/logs.test.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { isQuiet, isDebug, parserOutput } from '../../src/parsers/output.js';
 import { Write } from '../../src/services/write.js';

--- a/test/unit/map-tests.test.ts
+++ b/test/unit/map-tests.test.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { test } from '../../src/modules/helpers/test.js';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { beforeEach, afterEach } from '../../src/modules/helpers/each.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import {

--- a/test/unit/run-test-file.test.ts
+++ b/test/unit/run-test-file.test.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { runTestFile } from '../../src/services/run-test-file.js';
 import { getRuntime } from '../../src/parsers/get-runtime.js';

--- a/test/unit/run-tests.test.ts
+++ b/test/unit/run-tests.test.ts
@@ -1,5 +1,5 @@
 import { describe } from '../../src/modules/helpers/describe.js';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { runTests } from '../../src/services/run-tests.js';
 

--- a/test/unit/watch.test.ts
+++ b/test/unit/watch.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { it } from '../../src/modules/helpers/it.js';
+import { it } from '../../src/modules/helpers/it/core.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { beforeEach, afterEach } from '../../src/modules/helpers/each.js';
 import { assert } from '../../src/modules/essentials/assert.js';


### PR DESCRIPTION
This simple refactoring will help with the development of complementary methods such as `it.todo`, `it.skip`, etc.

- All changes in the `it` method are automatically reflected in the `test` method.

### Related

- #563
- https://github.com/wellwelwel/poku/issues/580#issuecomment-2248238733
