### PR TITLE
perf: improve concurrency defaults (inspired by Jest definitions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,9 @@ To see the detailed documentation, please visit the [**Documentation**](https://
 
 **Poku** is [continuously tested](https://github.com/wellwelwel/poku/blob/main/.github/workflows/ci_benchmark.yml) to ensure the following expectations for basic usage:
 
-- \>=**4x** faster than [**Jest**](https://github.com/jestjs/jest) (v29.7.0)
-- \>=**3x** faster than [**Vitest**](https://github.com/vitest-dev/vitest) (v1.6.0)
-- \>=**1x** faster than [**Mocha**](https://github.com/mochajs/mocha) (v10.4.0) + [**Chai**](https://github.com/chaijs/chai) (v5.1.1)
+- ~**4x** faster than [**Jest**](https://github.com/jestjs/jest) (v29.7.0)
+- ~**3x** faster than [**Vitest**](https://github.com/vitest-dev/vitest) (v1.6.0)
+- ~**1x** faster than [**Mocha**](https://github.com/mochajs/mocha) (v10.4.0) + [**Chai**](https://github.com/chaijs/chai) (v5.1.1)
 
 > You can see how the tests are run and compared in the [benchmark](https://github.com/wellwelwel/poku/tree/main/benchmark) directory.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -18,9 +18,9 @@ The testers to be compared are chosen based on the three most downloaded test ru
 
 **Poku** is continuously tested ([**CI**](https://github.com/wellwelwel/poku/blob/main/.github/workflows/ci_benchmark.yml)) to ensure the following expectations for basic usage:
 
-- \>=**4x** faster than [**Jest**](https://github.com/jestjs/jest) (v29.7.0)
-- \>=**3x** faster than [**Vitest**](https://github.com/vitest-dev/vitest) (v1.6.0)
-- \>=**1x** faster than [**Mocha**](https://github.com/mochajs/mocha) (v10.4.0) + [**Chai**](https://github.com/chaijs/chai) (v5.1.1)
+- ~**4x** faster than [**Jest**](https://github.com/jestjs/jest) (v29.7.0)
+- ~**3x** faster than [**Vitest**](https://github.com/vitest-dev/vitest) (v1.6.0)
+- ~**1x** faster than [**Mocha**](https://github.com/mochajs/mocha) (v10.4.0) + [**Chai**](https://github.com/chaijs/chai) (v5.1.1)
 
 ---
 

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -15,7 +15,7 @@ const test = () => {
   const pokuResult = results.get('Poku (Local)');
 
   const tolerancesPerTester = {
-    Jest: 4,
+    Jest: 3.9,
     'Mocha + Chai': 1,
     Vitest: 3,
     Poku: 0.8,

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -14,6 +14,7 @@ import { watch, type Watcher } from '../services/watch.js';
 import { onSigint, poku } from '../modules/essentials/poku.js';
 import { Write } from '../services/write.js';
 import { getConfigs } from '../parsers/options.js';
+import { availableParallelism } from '../polyfills/cpus.js';
 
 (async () => {
   const configFile = getArg('config') || getArg('c', '-');
@@ -215,7 +216,12 @@ import { getConfigs } from '../parsers/options.js';
                         return;
                       }
 
-                      poku(Array.from(tests), options).then(() => {
+                      poku(Array.from(tests), {
+                        ...options,
+                        concurrency:
+                          concurrency ??
+                          Math.max(Math.floor(availableParallelism() / 2), 1),
+                      }).then(() => {
                         setTimeout(() => {
                           executing.delete(filePath);
                         }, interval);

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -90,7 +90,7 @@ export const runTestsParallel = async (
   const files = await listFiles(testDir, configs);
   const filesByConcurrency: string[][] = [];
   const concurrencyLimit =
-    configs?.concurrency ?? Math.max(Math.floor(availableParallelism() / 2), 1);
+    configs?.concurrency ?? Math.max(availableParallelism() - 1, 1);
   const concurrencyResults: (boolean | undefined)[][] = [];
   const showLogs = !isQuiet(configs);
 

--- a/website/docs/comparing.mdx
+++ b/website/docs/comparing.mdx
@@ -22,9 +22,9 @@ import TabItem from '@theme/TabItem';
 
 **Poku** is [continuously tested](https://github.com/wellwelwel/poku/blob/main/.github/workflows/ci_benchmark.yml) to ensure the following expectations for basic usage:
 
-- \>=**4x** faster than [**Jest**](https://github.com/jestjs/jest) (v29.7.0)
-- \>=**3x** faster than [**Vitest**](https://github.com/vitest-dev/vitest) (v1.6.0)
-- \>=**1x** faster than [**Mocha**](https://github.com/mochajs/mocha) (v10.4.0) + [**Chai**](https://github.com/chaijs/chai) (v5.1.1)
+- ~**4x** faster than [**Jest**](https://github.com/jestjs/jest) (v29.7.0)
+- ~**3x** faster than [**Vitest**](https://github.com/vitest-dev/vitest) (v1.6.0)
+- ~**1x** faster than [**Mocha**](https://github.com/mochajs/mocha) (v10.4.0) + [**Chai**](https://github.com/chaijs/chai) (v5.1.1)
 
 > You can see how the tests are run and compared in the [benchmark](https://github.com/wellwelwel/poku/tree/main/benchmark) directory.
 

--- a/website/docs/documentation/poku/options/concurrency.mdx
+++ b/website/docs/documentation/poku/options/concurrency.mdx
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 When using `parallel` option, use `concurrency` to limit the number of tests running concurrently.
 
-The default value is half of the available cores or, when available, the `os.availableParallelism()` method is used. Otherwise **Poku** looks at the `os.cpus().length` or sets the value to `1`.
+The default value is the number of available cores (or `os.availableParallelism()` if available) minus `1`. In **watch mode**, it uses half the number of available cores (or `os.availableParallelism()` if available).
 
 ## CLI
 
@@ -26,5 +26,5 @@ await poku('./test', {
 <hr />
 
 :::tip
-To allow unlimited parallelism set the value to `0`.
+To allow unlimited parallelism, set the value to `0`.
 :::


### PR DESCRIPTION
Adapted and inspired by:

https://github.com/jestjs/jest/blob/b8c5200451b89bab85e42f5e9a29bcd13d00c894/packages/jest-config/src/getMaxWorkers.ts#L38

After this _PR_:

- The default value is the number of available cores (or `os.availableParallelism()` if available) minus `1`.
- In **watch mode**, it uses half the number of available cores (or `os.availableParallelism()` if available).

Previously, both common execution and watch mode used the same value _(half)_.

---

### Related

- #611

> cc: @mrazauskas 