### PR TITLE
docs: add pt-BR translation to Helpers and Examples sections

### DIFF
--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/list-files.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/list-files.mdx
@@ -1,0 +1,71 @@
+import { History } from '@site/src/components/History';
+
+# 🗄️ List Files
+
+Retorna todos os arquivos em um diretório (independente de sua profundidade) ou o próprio arquivo.
+
+<History
+  records={[
+    {
+      version: '2.4.0',
+      changes: [<>Suporte para uso via CLI.</>],
+    },
+  ]}
+/>
+
+## CLI
+
+Exibe todos os arquivos retornados no terminal, sem executar os testes.
+
+```sh
+npx poku --list-files
+```
+
+```sh
+npx poku ./test --list-files
+```
+
+```sh
+npx poku ./packages/**/test --list-files
+```
+
+```sh
+npx poku ./test/unit ./test/e2e --list-files
+```
+
+- Você pode usar as flags `--filter` e `--exclude` e incluir múltiplos caminhos.
+
+:::note
+
+Os arquivos retornados pelo `--list-files` não refletem os caminhos exibidos pelo `--debug`:
+
+- **`--debug`:** os caminhos a serem pesquisados.
+- **`--list-files`:** os caminhos encontrados.
+
+:::
+
+:::tip
+Se você passar flags diferentes de `--filter` e `--exclude`, elas serão ignoradas.
+:::
+
+## API
+
+> `listFiles(diretórioDeDestino: string, configs?: ListFilesConfigs)`
+
+```ts
+import { listFiles } from 'poku';
+
+await listFiles('algum-diretório');
+```
+
+- Você pode usar as opções `filter` e `exclude`, assim como são usadas no método **`poku`**.
+
+:::info
+
+Para compilar testes usando `listFiles` com **TypeScript**, você pode precisar instalar o **@types/node**:
+
+```bash
+npm i -D @types/node
+```
+
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/log.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/log.mdx
@@ -1,0 +1,15 @@
+# 📝 Log
+
+Como por padrão o **Poku** só exibe saídas geradas por ele mesmo, este auxiliar permite usar uma alternativa ao `console.log` com o executor do **Poku**.
+
+```ts
+import { log } from 'poku';
+
+log('o Poku irá exibir isso');
+
+console.log("O poku não irá exibir isso");
+```
+
+:::tip
+Precisa depurar? Basta usar a opção [`debug`](/docs/documentation/poku/options/debug) do `poku`.
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/log.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/log.mdx
@@ -7,7 +7,7 @@ import { log } from 'poku';
 
 log('o Poku irá exibir isso');
 
-console.log("O poku não irá exibir isso");
+console.log('O poku não irá exibir isso');
 ```
 
 :::tip

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/get-pids.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/get-pids.mdx
@@ -1,0 +1,73 @@
+---
+tags: [processes, ports, debug]
+---
+
+# Buscando PIDs
+
+Retorna os IDs dos processos usados pelas portas e intervalos de portas especificados.
+
+## getPIDs
+
+Retorna todos os IDs dos processos usados pelas portas especificadas.
+
+> `getPIDs(porta: number | number[])`
+
+- Requer `lsof` para **Unix** e `netstat` para **Windows**.
+
+```ts
+import { getPIDs } from 'poku';
+
+await getPIDs(4000);
+```
+
+```ts
+await getPIDs([4000, 4001]);
+```
+
+---
+
+## getPIDs.range
+
+Retorna todos os IDs dos processos usados pelo intervalo de portas especificado.
+
+> `getPIDs.range(iniciaEm: number, terminaEm: number)`
+
+- Requer `lsof` para **Unix** e `netstat` para **Windows**.
+
+```ts
+import { getPIDs } from 'poku';
+
+await getPIDs.range(4000, 4100);
+```
+
+---
+
+:::tip
+
+Se o seu ambiente não incluir o `lsof` por padrão:
+
+**macOS (Homebrew)**
+
+```sh
+brew install lsof
+```
+
+**Debian, Ubuntu, etc.**
+
+```sh
+sudo apt-get install lsof
+```
+
+**Arch Linux, etc.**
+
+```sh
+sudo pacman -S lsof
+```
+
+**Alpine Linux, etc.**
+
+```sh
+apk add lsof
+```
+
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/kill.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/kill.mdx
@@ -1,0 +1,144 @@
+---
+sidebar_position: 1
+tags: [processes, ports]
+---
+
+# Encerrando Processos
+
+Encerra as portas especificadas, intervalos de portas e IDs de processos.
+
+## kill.port
+
+> `kill.port(porta: number | number[])`
+
+Encerra as portas especificadas
+
+- Requer `lsof` para **Unix** e `netstat` para **Windows**.
+
+### CLI
+
+Encerra as portas especificadas antes de executar a suíte de testes.
+
+```bash
+npx poku --kill-port="4000" caminhoDoTeste
+```
+
+Também, encerrando múltiplas portas:
+
+```bash
+npx poku --kill-port="4000,4001" caminhoDoTeste
+```
+
+### API
+
+```ts
+import { kill } from 'poku';
+
+await kill.port(4000);
+```
+
+Também, encerrando múltiplas portas:
+
+```ts
+await kill.port([4000, 4001]);
+```
+
+---
+
+## kill.range
+
+> `kill.range(iniciaEm: number, terminaEm: number)`
+
+Encerra o intervalo de portas especificado.
+
+- Requer `lsof` para **Unix** e `netstat` para **Windows**.
+
+### CLI
+
+Encerra o intervalo de portas especificado antes de executar a suíte de testes.
+
+```bash
+npx poku --kill-range="4000-4100" caminhoDoTeste
+```
+
+Também, encerrando múltiplos intervalos de portas:
+
+```bash
+npx poku --kill-range="4000-4100,5000-5100" caminhoDoTeste
+```
+
+### API
+
+```ts
+import { kill } from 'poku';
+
+await kill.range(4000, 4100);
+```
+
+---
+
+## kill.pid
+
+> `kill.pid(PID: number | number[])`
+
+Encerra os processos especificados.
+
+### CLI
+
+Encerra os processos especificados antes de executar a suíte de testes
+
+```bash
+npx poku --kill-pid="100" caminhoDoTeste
+```
+
+Também, encerrando múltiplos processos:
+
+```bash
+npx poku --kill-pid="100,200" caminhoDoTeste
+```
+
+### API
+
+```ts
+import { kill } from 'poku';
+
+await kill.pid(100);
+```
+
+Também, encerrando múltiplos processos:
+
+```ts
+await kill.pid([100, 200]);
+```
+
+---
+
+:::tip
+
+Se o seu ambiente não incluir o `lsof` por padrão:
+
+**macOS (Homebrew)**
+
+```sh
+brew install lsof
+```
+
+**Debian, Ubuntu, etc.**
+
+```sh
+sudo apt-get install lsof
+```
+
+**Arch Linux, etc.**
+
+```sh
+sudo pacman -S lsof
+```
+
+**Alpine Linux, etc.**
+
+```sh
+apk add lsof
+```
+
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -9,7 +9,7 @@ import { FAQ } from '@site/src/components/FAQ';
 
 Semelhante ao `assert`, mas em vez de retornar um erro na comparação, ele tentará novamente até obter sucesso ou exceder o tempo limite.
 
-> Espera que conexões, serviços externos estajam prontos ou que um resultado específico de um método esteja disponível antes de iniciar os testes.
+> Espera até que conexões, serviços externos estejam prontos ou que um resultado específico de um método esteja disponível antes de iniciar os testes.
 
 ## waitForExpectedResult
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -5,7 +5,7 @@ tags: [flakey, containers]
 
 import { FAQ } from '@site/src/components/FAQ';
 
-# Aguardando pelos Resultados Esperados
+# Aguardando por Resultados Esperados
 
 Semelhante ao `assert`, mas em vez de retornar um erro na comparação, ele tentará novamente até obter sucesso ou o tempo limite.
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -85,7 +85,7 @@ await waitForExpectedResult(() => db.connect(), true);
 
 <hr />
 
-Aguardando para que a conexão com o banco de dados não lance uma exceção:
+Aguardando até que a conexão com o banco de dados não lance uma exceção:
 
 ```ts
 import { waitForExpectedResult } from 'poku';

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -1,0 +1,154 @@
+---
+sidebar_position: 3
+tags: [flakey, containers]
+---
+
+import { FAQ } from '@site/src/components/FAQ';
+
+# Aguardando pelos Resultados Esperados
+
+Semelhante ao `assert`, mas em vez de retornar um erro na comparação, ele tentará novamente até obter sucesso ou o tempo limite.
+
+> Espera que conexões, serviços externos estajam prontos ou que um resultado específico de um método esteja disponível antes de iniciar os testes.
+
+## waitForExpectedResult
+
+```ts
+import { waitForExpectedResult } from 'poku';
+
+await waitForExpectedResult(() => true, true, {
+  delay: 0,
+  interval: 100,
+  timeout: 60000,
+  strict: false,
+});
+```
+
+<hr />
+
+<FAQ title='Options' >
+
+```ts
+export type WaitForExpectedResultOptions = {
+  /**
+   * Intervalo de repetição em milissegundos
+   *
+   * ---
+   *
+   * @default 100
+   */
+  interval?: number;
+  /**
+   * Tempo limite em milissegundos
+   *
+   * ---
+   *
+   * @default 60000
+   */
+  timeout?: number;
+  /**
+   * Atrasa o início e o fim pelo número definido de milissegundos.
+   *
+   * ---
+   *
+   * @default 0
+   */
+  delay?: number;
+  /**
+   * Garante comparações estritas.
+   *
+   * - Para usuários do **Bun**, essa opção não é necessária.
+   *
+   * ---
+   *
+   * @default false
+   */
+  strict?: boolean;
+};
+```
+
+</FAQ>
+
+<hr />
+
+## Exemplos
+
+Aguardando pela conexão com o banco de dados retornar `true`:
+
+```ts
+import { waitForExpectedResult } from 'poku';
+import { db } from './db.js';
+
+await waitForExpectedResult(() => db.connect(), true);
+// await waitForExpectedResult(async () => await db.connect(), true);
+```
+
+<hr />
+
+Aguardando para que a conexão com o banco de dados não lance uma exceção:
+
+```ts
+import { waitForExpectedResult } from 'poku';
+import { db } from './db.js';
+
+await waitForExpectedResult(async () => {
+  try {
+    await db.connect();
+    return true;
+  } catch {}
+}, true);
+```
+
+<hr />
+
+Aguardando por uma conexão com o banco de dados de um contêiner antes de executar toda a suíte de testes e parando o contêiner ao finalizar:
+
+> Exemplo de _API_ do **Poku**.
+
+```ts
+import { poku, docker, waitForExpectedResult, exit } from 'poku';
+import { db } from './db.js';
+
+// Carrega o docker-compose.yml
+const compose = docker.compose();
+
+// Inicia o contêiner
+await compose.up();
+
+// Aguardando pelo banco de dados
+await waitForExpectedResult(async () => {
+  try {
+    await db.connect();
+    return true;
+  } catch {}
+}, true);
+
+// Inicia a suíte de testes
+const result = await poku('./test/integration', {
+  noExit: true,
+});
+
+// Finaliza o contêiner
+await compose.down();
+
+// Mostra os resultados dos testes e encerra o processo com o código de saída dos testes.
+exit(result);
+```
+
+<blockquote>
+
+Então:
+
+```sh
+node run.test.js
+```
+
+```sh
+npx tsx run.test.ts
+```
+
+</blockquote>
+
+:::tip
+[Veja um exemplo usando o **Dockerfile**.](/docs/documentation/helpers/containers#dockerfile)
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -7,7 +7,7 @@ import { FAQ } from '@site/src/components/FAQ';
 
 # Aguardando por Resultados Esperados
 
-Semelhante ao `assert`, mas em vez de retornar um erro na comparação, ele tentará novamente até obter sucesso ou o tempo limite.
+Semelhante ao `assert`, mas em vez de retornar um erro na comparação, ele tentará novamente até obter sucesso ou exceder o tempo limite.
 
 > Espera que conexões, serviços externos estajam prontos ou que um resultado específico de um método esteja disponível antes de iniciar os testes.
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-expected-result.mdx
@@ -73,7 +73,7 @@ export type WaitForExpectedResultOptions = {
 
 ## Exemplos
 
-Aguardando pela conexão com o banco de dados retornar `true`:
+Aguardando até a conexão com o banco de dados retornar `true`:
 
 ```ts
 import { waitForExpectedResult } from 'poku';

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-port.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-port.mdx
@@ -87,24 +87,24 @@ await Promise.all([
 ```ts
 import { docker, waitForPort } from 'poku';
 
-// destaca-início
+// highlight-start
 const compose = docker.compose();
 
 await compose.up();
-// destaca-fim
+// highlight-end
 await waitForPort(3000, { delay: 100 });
 
-// destaca-início
+// highlight-start
 const res = await fetch('http://localhost:3000');
-// destaca-fim
+// highlight-end
 
 /**
  * Os testes vêm aqui 🧪
  */
 
-// destaca-início
+// highlight-start
 await compose.down();
-// destaca-fim
+// highlight-end
 ```
 
 <hr />

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-port.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/processes/wait-for-port.mdx
@@ -1,0 +1,123 @@
+---
+sidebar_position: 2
+tags: [flakey, containers]
+---
+
+import { FAQ } from '@site/src/components/FAQ';
+
+# Aguardando Portas
+
+Aguarda as portas especificadas se tornarem ativas.
+
+## waitForPort
+
+```ts
+import { waitForPort } from 'poku';
+
+await waitForPort(3000, {
+  delay: 0,
+  interval: 100,
+  timeout: 60000,
+  host: 'localhost',
+});
+```
+
+<hr />
+
+<FAQ title='Options' >
+
+```ts
+export type WaitForPortOptions = {
+  /**
+   * Intervalo de tentativa em milissegundos
+   *
+   * ---
+   *
+   * @default 100
+   */
+  interval?: number;
+  /**
+   * Tempo limite em milissegundos
+   *
+   * ---
+   *
+   * @default 60000
+   */
+  timeout?: number;
+  /**
+   * Atrasa o início e o fim pelo número definido de milissegundos.
+   *
+   * ---
+   *
+   * @default 0
+   */
+  delay?: number;
+  /**
+   * Host para verificar a porta.
+   *
+   * ---
+   *
+   * @default "localhost"
+   */
+  host?: string;
+};
+```
+
+</FAQ>
+
+<hr />
+
+## Exemplos
+
+### Aguardando Múltiplas Portas
+
+```ts
+import { waitForPort } from 'poku';
+
+await Promise.all([
+  waitForPort(3000),
+  waitForPort(4000),
+  waitForPort(5000),
+  waitForPort(6000),
+]);
+```
+
+### Aguardando um Serviço de Container na Porta 3000
+
+```ts
+import { docker, waitForPort } from 'poku';
+
+// destaca-início
+const compose = docker.compose();
+
+await compose.up();
+// destaca-fim
+await waitForPort(3000, { delay: 100 });
+
+// destaca-início
+const res = await fetch('http://localhost:3000');
+// destaca-fim
+
+/**
+ * Os testes vêm aqui 🧪
+ */
+
+// destaca-início
+await compose.down();
+// destaca-fim
+```
+
+<hr />
+
+:::tip
+
+O **Poku** expõe um auxiliar `sleep` mínimo que apenas espera por milissegundos, além do `waitForPort`:
+
+```ts
+import { sleep } from 'poku';
+
+// Aguarda por 1 segundo
+await sleep(1000);
+```
+
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/skip.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/skip.mdx
@@ -32,20 +32,20 @@ Imagine que um teste específico não funcione em um _SO_ específico:
 
 ```ts
 import { test, skip } from 'poku';
-// destaca-início
+// highlight-start
 import { platform } from 'node:process';
 
 const isWindows = platform === 'win32';
 
-// destaca-fim
+// highlight-end
 if (isWindows) skip('Pulando devido à incompatibilidade com o Windows');
 
 // Executa testes normalmente em outros sistemas operacionais
-// destaca-início
+// highlight-start
 test(() => {
   // ...
 });
-// destaca-fim
+// highlight-end
 ```
 
 :::note

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/startService.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/startService.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 7
-tags: [background, server, service, package.json, scripts]
+sidebar_position: 8
+tags: [background, server, service]
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,25 +8,15 @@ import TabItem from '@theme/TabItem';
 import { FAQ } from '@site/src/components/FAQ';
 import Success from '@site/static/img/success.svg';
 
-# 🔁 Start Script
+# 🔁 Start Service
 
-Execute seus scripts do `package.json` em um processo em segundo plano e teste-os 🧑🏻‍🔬
+Execute seus serviços em um processo em segundo plano e teste-o 🧑🏻‍🔬
 
-> startScript(caminhoDoArquivo: string, opções?: startScriptOptions);
+> startService(caminhoDoArquivo: string, opções?: StartServiceOptions);
 
-O `startScript` executa um script diretamente do seu `package.json` ou `deno.json` e o mantém em execução em um processo em segundo plano até que você o libere.
+O `startService` executa um arquivo diretamente e mantém-o em execução em um processo em segundo plano até que você o libere.
 
 <div className='features black'>
-  <div className='p'>
-    <Success />
-    <span>
-      Bastante útil para testar seu
-      [**NextJS**](https://github.com/vercel/next.js),
-      [**NuxtJS**](https://github.com/nuxt/nuxt),
-      [**nodemon**](https://github.com/remy/nodemon) e todos os apps do projeto
-      🚀
-    </span>
-  </div>
   <div className='p'>
     <Success />
     <span>Permite que **cookies** persistam (_ou não_) 🍪</span>
@@ -41,8 +31,8 @@ O `startScript` executa um script diretamente do seu `package.json` ou `deno.jso
   <div className='p'>
     <Success />
     <span>
-      Não é necessário adicionar plugins externos para algo tão simples, basta
-      executá-lo como está 🌱
+      não é necessário exportar seu app, server ou qualquer serviço, basta
+      executá-lo como está 🚀
     </span>
   </div>
   <div className='p'>
@@ -76,9 +66,9 @@ Definindo um tempo limite, você evita processos indefinidos que não concluem n
 Você não precisa necessariamente encerrar seu serviço em segundo plano como a última linha do teste, se ele não estiver mais em uso.
 
 ```ts
-import { startScript } from 'poku';
+import { startService } from 'poku';
 
-const server = await startScript('start', {
+const server = await startService('server.js', {
   /**
    * Espere pelo "ready" na saída do console
    */
@@ -130,7 +120,7 @@ kill -9 PID
 ## Opções Disponíveis
 
 ```ts
-type StartScriptOptions = {
+type StartServiceOptions = {
   /**
    * - Por padrão, será resolvido na primeira saída do console
    * - Definindo uma string: ele aguardará uma string específica na saída do console para resolver
@@ -161,9 +151,9 @@ type StartScriptOptions = {
    */
   cwd?: string | undefined;
   /**
-   * Por padrão, o Poku usará o `npm`. Altere conforme desejar.
+   * Por padrão, o Poku tentará identificar a plataforma atual, mas você pode especificá-la manualmente
    */
-  runner?: 'npm' | 'bun' | 'deno' | 'yarn' | 'pnpm';
+  platform?: 'node' | 'bun' | 'deno';
 };
 
 type End = (port?: number | number[]) => Promise<void>;

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/startService.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/startService.mdx
@@ -10,7 +10,7 @@ import Success from '@site/static/img/success.svg';
 
 # 🔁 Start Service
 
-Execute seus serviços em um processo em segundo plano e teste-o 🧑🏻‍🔬
+Execute seus serviços em um processo em segundo plano e teste-os 🧑🏻‍🔬
 
 > startService(caminhoDoArquivo: string, opções?: StartServiceOptions);
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/startService.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/startService.mdx
@@ -52,7 +52,7 @@ O `startService` executa um arquivo diretamente e mantém-o em execução em um 
 
 ## Boas Práticas 👮🏽
 
-### ✅ Sinalize o status "pronto"
+### ✅ Sinalize o status "ready"
 
 Quando possível, defina uma saída do console para indicar que o serviço está pronto. <br />
 Isso irá permitir que você evite execuções prematuras e vazamentos de porta.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/todo.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/helpers/todo.mdx
@@ -1,0 +1,61 @@
+---
+sidebar_position: 10
+tags: [boilerplate]
+---
+
+# 📋 todo
+
+O `.todo` é um auxiliar estendido para `describe`, `it` e `test` para ajudá-lo a planejar testes futuros.
+
+## Uso Básico
+
+### Mensagem simples
+
+```ts
+import { describe, it, test } from 'poku';
+
+describe.todo('todo: Teste Futuro');
+
+it.todo('todo: Teste Futuro');
+
+test.todo('todo: Teste Futuro');
+```
+
+- Não há diferença entre as funcionalidades.
+
+Também em contextos internos:
+
+```ts
+import { describe, it } from 'poku';
+
+describe(() => {
+  it.todo('todo: Teste Futuro');
+
+  it('Teste real', () => {
+    /* ... */
+  });
+});
+```
+
+### Ignorando um callback
+
+Isso pode ser útil quando você já tem uma ideia ou protótipo do que deseja testar, mas não quer que o teste seja executado de fato.<br />
+Também pode ser útil para testes que pararam de funcionar inesperadamente devido a algum evento externo, necessitando de maior atenção.
+
+```ts
+import { describe, it } from 'poku';
+
+describe.todo('todo: Teste Futuro', () => {
+  it(async () => {
+    process.exit(1);
+  });
+});
+```
+
+- O método recebido por `todo` e tudo dentro dele será completamente ignorado.
+
+<hr />
+
+:::note
+Ao usar `beforeEach` ou `afterEach`, eles não serão acionados por testes com `.todo`.
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
@@ -73,7 +73,7 @@ npx poku caminhoDoTesteA caminhoDoTesteB
 
 <hr />
 
-### Estendendo os padrões Glob do shell
+### Estendendo padrões Glob a partir do shell
 
 Você também pode estender os **padrões do Glob** com `npx`, `bun`, `yarn`, etc.
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
@@ -27,7 +27,8 @@ Por padrão, o **Poku** busca por arquivos _`.test.`_ e `.spec.`, mas você pode
         </>,
       ],
     },
-  ]}
+
+]}
 />
 
 ## CLI
@@ -101,7 +102,7 @@ npx poku --filter='' ./packages/**/test/unit/*.js
 <Stability
   level={0}
   message={
-    "Agora é possível passar múltiplos caminhos em qualquer posição desde a v2.1.0."
+    'Agora é possível passar múltiplos caminhos em qualquer posição desde a v2.1.0.'
   }
 />
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
@@ -89,7 +89,7 @@ Agora, listando todos os arquivos `.js` em vez do padrão `.test.|.spec.`:
 npx poku --filter='.js' ./packages/**/test/unit
 ```
 
-Além disso, ignorando o filtro:
+Ou também, ao anular o `filter`:
 
 ```sh
 npx poku --filter='' ./packages/**/test/unit/*.js

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/include-files.mdx
@@ -1,0 +1,138 @@
+---
+sidebar_position: 1
+---
+
+import { History } from '@site/src/components/History';
+import { Stability } from '@site/src/components/Stability';
+
+# 📦 Incluir Diretórios e Arquivos
+
+Por padrão, o **Poku** busca por arquivos _`.test.`_ e `.spec.`, mas você pode customizá-lo usando a opção [`filter`](/docs/documentation/poku/options/filter).
+
+<History
+  records={[
+    {
+      version: '2.1.0',
+      changes: [
+        <>Suporte para múltiplos caminhos em qualquer ordem.</>,
+        <>
+          Flag <code>--include</code> depreciada.
+        </>,
+         <>
+          Mantém suporte retroativo para múltiplos caminhos separados por
+          vírgula para evitar mudanças incompatíveis.
+        </>,
+        <>
+
+        </>,
+      ],
+    },
+  ]}
+/>
+
+## CLI
+
+### Uso Comum
+
+```bash
+# Equivalente à ./
+npx poku
+```
+
+- Executa todos os testes sequencialmente.
+
+```bash
+# Equivalente à ./
+npx poku --parallel
+```
+
+- Executa todos os testes em paralelo.
+
+```bash
+npx poku ./test
+```
+
+- Executa todos os testes do diretório `./test`.
+
+:::tip
+Você pode passar tanto diretórios quanto arquivos.
+:::
+
+:::note
+Não é possível executar testes nos diretórios `.git` e `node_modules`.
+:::
+
+<hr />
+
+### Definindo múltiplos caminhos
+
+```bash
+npx poku caminhoDoTesteA caminhoDoTesteB
+```
+
+<hr />
+
+### Estendendo os padrões Glob do shell
+
+Você também pode estender os **padrões do Glob** com `npx`, `bun`, `yarn`, etc.
+
+Por exemplo, executando todos os testes unitários de um _monorepo_:
+
+```sh
+npx poku ./packages/**/test/unit
+```
+
+Agora, listando todos os arquivos `.js` em vez do padrão `.test.|.spec.`:
+
+```sh
+npx poku --filter='.js' ./packages/**/test/unit
+```
+
+Além disso, ignorando o filtro:
+
+```sh
+npx poku --filter='' ./packages/**/test/unit/*.js
+```
+
+<hr />
+
+### `--include`
+
+<Stability
+  level={0}
+  message={
+    "Agora é possível passar múltiplos caminhos em qualquer posição desde a v2.1.0."
+  }
+/>
+
+<hr />
+
+## API
+
+> `poku(caminhosDoTestes: string | string[])`
+
+```ts
+await poku('caminhoDoTeste');
+```
+
+```ts
+await poku(['caminhoDoTesteA', 'caminhoDoTesteB']);
+```
+
+```ts
+await poku('./');
+```
+
+<blockquote>
+
+Em seguida, execute o arquivo diretamente com a plataforma de sua escolha, por exemplo:
+
+```bash
+node test/run.test.js
+```
+
+```bash
+npx tsx test/run.test.ts
+```
+
+</blockquote>

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -39,7 +39,7 @@ Bun.serve({
     }),
 });
 
-console.log('pronto');
+console.log('ready');
 // highlight-end
 ```
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -1,0 +1,200 @@
+---
+sidebar_position: 1
+tags: [background, server, service, package.json, scripts, supertest]
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import { FAQ } from '@site/src/components/FAQ';
+
+# Servidor Local
+
+Vamos criar um servidor simples:
+
+<Tabs>
+  <TabItem default value='server.js (Node.js)'>
+
+```js
+// highlight-start
+import { createServer } from 'node:http';
+
+createServer((_, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ name: 'Poku' }));
+}).listen(4000, () => console.log('pronto'));
+
+// highlight-end
+```
+
+  </TabItem>
+  <TabItem default value='server.js (Bun)'>
+
+```js
+// highlight-start
+Bun.serve({
+  port: 4000,
+  fetch: () =>
+    new Response(JSON.stringify({ name: 'Poku' }), {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+});
+
+console.log('pronto');
+// highlight-end
+```
+
+  </TabItem>
+  <TabItem default value='server.js (Deno)'>
+
+```ts
+// highlight-start
+Deno.serve({
+  port: 4000,
+  handler: () =>
+    new Response(JSON.stringify({ name: 'Poku' }), {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  onListen: () => console.log('pronto'),
+});
+// highlight-end
+```
+
+  </TabItem>
+</Tabs>
+
+E agora, teste-o:
+
+<Tabs>
+  <TabItem default value='test/server.test.js'>
+
+```js
+import { assert, startService } from 'poku';
+
+const server = await startService('server.js', {
+  // Aguarde pelo "pronto" na saída do console
+  startAfter: 'pronto',
+});
+
+// Use a biblioteca de requisições que preferir
+// highlight-start
+const res = await fetch('http://localhost:4000');
+const data = await res.json();
+// highlight-end
+
+assert.strictEqual(res.status, 200, 'O servidor está ativo');
+assert.deepStrictEqual(data, { name: 'Poku' }, 'O Poku está aqui');
+
+server.end();
+```
+
+  </TabItem>
+</Tabs>
+
+<FAQ title='Precisa testar usando uma sessão consistente? 🍪'>
+
+**Apenas faça isso** 🚀
+
+Aqui está um exemplo usando [**Axios**](https://github.com/axios/axios):
+
+```js
+import { assert, startService } from 'poku';
+// highlight-start
+import axios from 'axios';
+import axiosCookieJarSupport from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
+
+// highlight-end
+const server = await startService('server.js');
+
+// highlight-start
+axiosCookieJarSupport(axios);
+
+const cookieJar = new CookieJar();
+
+export const api = axios.create({
+  withCredentials: true,
+  jar: cookieJar,
+});
+
+const { data } = await api.get('http://localhost:4000');
+// highlight-end
+
+assert.deepStrictEqual(data, { name: 'Poku' }, 'O Poku está aqui');
+```
+
+</FAQ>
+
+:::tip
+
+- **Biblioteca de requisições:** Você pode usar [**Axios**](https://github.com/axios/axios), [**Node Fetch**](https://github.com/node-fetch/node-fetch) ou qualquer outro que quiser 💙
+- **Servidor:** Você pode usar qualquer servidor que quiser, como [**Express**](https://github.com/expressjs/express), [**Koa**](https://github.com/koajs/koa), etc.
+- [**NextJS**](https://github.com/vercel/next.js), [**ViteJS**](https://github.com/vitejs/vite), [**nodemon**](https://github.com/remy/nodemon) e mais? Veja abaixo 👇🏻
+
+:::
+
+<hr />
+
+Você também pode iniciar seu servidor usando o `startScript`.
+
+<Tabs>
+  <TabItem default value='test/server.test.js'>
+
+```js
+import { assert, startScript } from 'poku';
+
+const server = await startScript('start', {
+  // Aguarde pelo "pronto" na saída do console
+  startAfter: 'pronto',
+});
+
+// Use a biblioteca de requisições que você preferir.
+// highlight-start
+const res = await fetch('http://localhost:4000');
+const data = await res.json();
+// highlight-end
+
+assert.strictEqual(res.status, 200, 'O servidor está ativo');
+assert.deepStrictEqual(data, { name: 'Poku' }, 'O Poku está aqui');
+
+server.end();
+```
+
+  </TabItem>
+  <TabItem default value='package.json (Node.js)'>
+
+```json
+{
+  "script": {
+    "start": "node server.js"
+  }
+}
+```
+
+  </TabItem>
+  <TabItem value='package.json (Bun)'>
+
+```json
+{
+  "script": {
+    "start": "bun server.js"
+  }
+}
+```
+
+  </TabItem>
+  <TabItem value='deno.json (Deno)'>
+
+```json
+{
+  "tasks": {
+    "start": "deno run --allow-net server.js"
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+:::tip
+Usando o `startScript`, você pode executar [**NextJS**](https://github.com/vercel/next.js), [**SvelteJS**](https://github.com/sveltejs/svelte), [**nodemon**](https://github.com/remy/nodemon) e todos os scripts que você sempre usou 🐷
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -72,7 +72,7 @@ import { assert, startService } from 'poku';
 
 const server = await startService('server.js', {
   // Aguarde pelo "ready" na saída do console
-  startAfter: 'pronto',
+  startAfter: 'ready',
 });
 
 // Use a biblioteca de requisições que preferir

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -54,7 +54,7 @@ Deno.serve({
     new Response(JSON.stringify({ name: 'Poku' }), {
       headers: { 'Content-Type': 'application/json' },
     }),
-  onListen: () => console.log('pronto'),
+  onListen: () => console.log('ready'),
 });
 // highlight-end
 ```

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -143,7 +143,7 @@ Você também pode iniciar seu servidor usando o `startScript`.
 import { assert, startScript } from 'poku';
 
 const server = await startScript('start', {
-  // Aguarde pelo "pronto" na saída do console
+  // Aguarde pelo "ready" na saída do console
   startAfter: 'pronto',
 });
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -21,7 +21,7 @@ import { createServer } from 'node:http';
 createServer((_, res) => {
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({ name: 'Poku' }));
-}).listen(4000, () => console.log('pronto'));
+}).listen(4000, () => console.log('ready'));
 
 // highlight-end
 ```

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -71,7 +71,7 @@ E agora, teste-o:
 import { assert, startService } from 'poku';
 
 const server = await startService('server.js', {
-  // Aguarde pelo "pronto" na saída do console
+  // Aguarde pelo "ready" na saída do console
   startAfter: 'pronto',
 });
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/local-server.mdx
@@ -144,7 +144,7 @@ import { assert, startScript } from 'poku';
 
 const server = await startScript('start', {
   // Aguarde pelo "ready" na saída do console
-  startAfter: 'pronto',
+  startAfter: 'ready',
 });
 
 // Use a biblioteca de requisições que você preferir.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/parameterized-tests.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/parameterized-tests.mdx
@@ -1,0 +1,82 @@
+---
+tags: [examples, promise, tutorial, parameterized, parametrized]
+sidebar_position: 0.5
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import MidLevel from '@site/static/img/mid-level.svg';
+
+# Testes parametrizados
+
+Testes parametrizados permite que você execute a mesma lógica de teste com diferentes entradas e resultados esperados. Isso ajuda a testar em vários cenários sem escrever testes repetitivos.
+
+Por exemplo:
+
+```ts
+import { assert, test } from 'poku';
+
+const casosDeTeste = [
+  {
+    esperado: true,
+    entrada: { name: 'Alice', role: 'admin' },
+    casoDeTeste: 'é admin',
+  },
+  {
+    esperado: false,
+    entrada: { name: 'Bob', role: 'user' },
+    casoDeTeste: 'não é admin',
+  },
+];
+
+const isAdmin = (user) => user.role === 'admin';
+
+for (const { esperado, entrada, casoDeTeste } of casosDeTeste) {
+  test(casoDeTeste, () => {
+    const atual = isAdmin(entrada);
+
+    assert.strictEqual(atual, esperado);
+  });
+}
+```
+
+## Usando promesas
+
+Lidando com operações assíncronas sequencialmente dentro de testes parametrizados usando promesas:
+
+```ts
+import { assert, test } from 'poku';
+
+const casosDeTeste = [
+  {
+    esperado: true,
+    entrada: { name: 'Alice', role: 'admin' },
+    casoDeTeste: 'é admin',
+  },
+  {
+    esperado: false,
+    entrada: { name: 'Bob', role: 'user' },
+    casoDeTeste: 'não é admin',
+  },
+];
+
+const isAdmin = (user) => Promise.resolve(user.role === 'admin');
+
+for (const { esperado, entrada, casoDeTeste } of casosDeTeste) {
+  await test(casoDeTeste, async () => {
+    const atual = await isAdmin(entrada);
+
+    assert.strictEqual(atual, esperado);
+  });
+}
+```
+
+:::tip
+Para executar operações assíncronas em paralelo, simplesmente remova `await` de `test` ou `it`.
+:::
+
+<hr />
+
+:::info
+Esses exemplos foram baseados [nesse comentário](https://github.com/wellwelwel/poku/issues/566#issuecomment-2241496155).
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/promises.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/promises.mdx
@@ -1,5 +1,4 @@
 ---
-title: Promises
 tags: [examples, promise, beforeAll, afterAll, tutorial, roadmap]
 sidebar_position: 0
 ---
@@ -8,7 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import MidLevel from '@site/static/img/mid-level.svg';
 
-# Promises
+# Promesas
 
 O uso da [sintaxe nativa **JavaScript** nos testes](/docs/philosophy#essência-do-javascript-para-testes-) é uma das principais diferenças entre o **Poku** e outros executores de testes, o que possibilita seu uso em várias plataformas.
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/promises.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/promises.mdx
@@ -1,0 +1,145 @@
+---
+title: Promises
+tags: [examples, promise, beforeAll, afterAll, tutorial, roadmap]
+sidebar_position: 0
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import MidLevel from '@site/static/img/mid-level.svg';
+
+# Promises
+
+O uso da [sintaxe nativa **JavaScript** nos testes](/docs/philosophy#essência-do-javascript-para-testes-) é uma das principais diferenças entre o **Poku** e outros executores de testes, o que possibilita seu uso em várias plataformas.
+
+:::tip
+Não é necessário usar `await` para testes que não são assíncronos.
+:::
+
+Aqui estão alguns exemplos de testes sequenciais e concorrentes no mesmo arquivo, além de como realizar uma ação após todos os testes terem sido concluídos:
+
+### Executando testes assíncronos no mesmo arquivo em paralelo
+
+```js
+import { test, assert, sleep } from 'poku';
+
+test(async () => {
+  const atual = 1;
+  const esperado = 1;
+
+  await sleep(2000);
+
+  assert.strictEqual(atual, esperado);
+});
+
+test(async () => {
+  const atual = 2;
+  const esperado = 2;
+
+  await sleep(1000);
+
+  assert.strictEqual(atual, esperado);
+});
+```
+
+<hr />
+
+### Executando testes assíncronos no mesmo arquivo sequencialmente (aguardando nível superior)
+
+```js
+import { test, assert, sleep } from 'poku';
+
+await test(async () => {
+  const atual = 1;
+  const esperado = 1;
+
+  await sleep(2000);
+
+  assert.strictEqual(atual, esperado);
+});
+
+await test(async () => {
+  const atual = 2;
+  const esperado = 2;
+
+  await sleep(1000);
+
+  assert.strictEqual(atual, esperado);
+});
+```
+
+<hr />
+
+### Executando testes assíncronos no mesmo arquivo sequencialmente
+
+```js
+import { describe, it, assert, sleep } from 'poku';
+
+describe(async () => {
+  await it(async () => {
+    const atual = 1;
+    const esperado = 1;
+
+    await sleep(2000);
+
+    assert.strictEqual(atual, esperado);
+  });
+
+  await it(async () => {
+    const atual = 2;
+    const esperado = 2;
+
+    await sleep(1000);
+
+    assert.strictEqual(atual, esperado);
+  });
+});
+```
+
+<hr />
+
+## Aguarando todos os testes serem executados para realizar uma ação posterior
+
+```js
+import { describe, it, assert, sleep } from 'poku';
+
+describe(async () => {
+  console.log('Imprimindo isso antes de todos os testes 🏃🏻‍♀️');
+
+  await Promise.all([
+    test(async () => {
+      const atual = 1;
+      const esperado = 1;
+
+      await sleep(2000);
+
+      assert.strictEqual(atual, esperado);
+    }),
+
+    test(async () => {
+      const atual = 2;
+      const esperado = 2;
+
+      await sleep(1000);
+
+      assert.strictEqual(atual, esperado);
+    }),
+  ]);
+
+  console.log('Imprimindo isso depois de todos os testes 😴');
+});
+```
+
+:::tip
+Para múltiplos `describe` ou `test` assíncronos, você também pode usar `await` para executá-los sequencialmente.
+:::
+
+<hr />
+
+:::danger Be careful
+Ao usar `beforeEach` and `afterEach` assíncronos, é necessário usar `await` mesmo que os auxiliares `test` ou `it` não tenham eventos assíncronos.
+:::
+
+:::note
+Se você encontrar algum erro de digitação, sinta-se à vontande para abrir um **Pull Request** corrigindo-o.
+:::

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/promises.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/examples/promises.mdx
@@ -9,7 +9,7 @@ import MidLevel from '@site/static/img/mid-level.svg';
 
 # Promesas
 
-O uso da [sintaxe nativa **JavaScript** nos testes](/docs/philosophy#essência-do-javascript-para-testes-) é uma das principais diferenças entre o **Poku** e outros executores de testes, o que possibilita seu uso em várias plataformas.
+O uso da [sintaxe nativa **JavaScript** nos testes](/docs/philosophy#javascript-essence-for-tests-) é uma das principais diferenças entre o **Poku** e outros executores de testes, o que possibilita seu uso em várias plataformas.
 
 :::tip
 Não é necessário usar `await` para testes que não são assíncronos.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/philosophy.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/philosophy.mdx
@@ -8,7 +8,9 @@ A filosofia do **Poku** se concentra na simplicidade e na eficiência, removendo
 
 <hr />
 
-## Essência do JavaScript para testes 💡
+<Heading as='h2' id='javascript-essence-for-tests-'>
+  Essência do JavaScript para testes 💡
+</Heading>
 
 > A sintaxe nativa do **JavaScript** para testes é o que torna possível usar o **Poku** em várias plataformas.
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/philosophy.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/philosophy.mdx
@@ -8,9 +8,7 @@ A filosofia do **Poku** se concentra na simplicidade e na eficiência, removendo
 
 <hr />
 
-<Heading as='h2' id='javascript-essence-for-tests-'>
-  Essência do JavaScript para testes 💡
-</Heading>
+## Essência do JavaScript para testes 💡
 
 > A sintaxe nativa do **JavaScript** para testes é o que torna possível usar o **Poku** em várias plataformas.
 


### PR DESCRIPTION
🇧🇷

Added pt-BR translation for below items:

### Include directories and files translation

### Helpers
- Start Script
- Kill
- Wait for ports
- Wait for expected result
- Get pids
- Todo
- List files
- Log

### Examples
- Promises
- Parameterized tests
- Local server