### PR TITLE
fix: propagate exit code when a failure occurs with `--fail-fast`

### DIFF
--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -1,5 +1,5 @@
 import type { Configs } from '../@types/poku.js';
-import { cwd as processCWD, hrtime } from 'node:process';
+import process from 'node:process';
 import { join, relative, sep } from 'node:path';
 import { runner } from '../parsers/get-runner.js';
 import { indentation } from '../configs/indentation.js';
@@ -11,7 +11,7 @@ import { isQuiet } from '../parsers/output.js';
 import { results } from '../configs/poku.js';
 import { availableParallelism } from '../polyfills/cpus.js';
 
-const cwd = processCWD();
+const cwd = process.cwd();
 
 export const runTests = async (
   dir: string,
@@ -37,9 +37,9 @@ export const runTests = async (
     const filePath = files[i];
     const fileRelative = relative(cwd, filePath);
 
-    const start = hrtime();
+    const start = process.hrtime();
     const testPassed = await runTestFile(filePath, configs);
-    const end = hrtime(start);
+    const end = process.hrtime(start);
     const total = (end[0] * 1e3 + end[1] / 1e6).toFixed(6);
 
     const testNumber = i + 1;
@@ -67,6 +67,8 @@ export const runTests = async (
       passed = false;
 
       if (configs?.failFast) {
+        process.exitCode = 1;
+
         if (showLogs) {
           Write.hr();
           Write.log(
@@ -111,6 +113,8 @@ export const runTestsParallel = async (
           ++results.fail;
 
           if (configs?.failFast) {
+            process.exitCode = 1;
+
             throw new Error(
               `  ${format('ℹ').fail()} ${format('fail-fast').bold()} is enabled`
             );

--- a/test/c8.test.ts
+++ b/test/c8.test.ts
@@ -52,8 +52,8 @@ test(async () => {
     await it('Sequential + Options (Just Touch)', async () => {
       const results = await inspectPoku(
         isWindows
-          ? '--concurrency=4 --platform=node --fast-fail --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" test/integration/import.test.ts --filter=".test.|.spec."'
-          : '--concurrency=4 --platform=node --fast-fail --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 test/integration/import.test.ts --filter=.test.|.spec.'
+          ? '--concurrency=4 --platform=node --fail-fast --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" test/integration/import.test.ts --filter=".test.|.spec."'
+          : '--concurrency=4 --platform=node --fail-fast --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 test/integration/import.test.ts --filter=.test.|.spec.'
       );
 
       console.log(results.stdout);
@@ -65,8 +65,8 @@ test(async () => {
     await it('Parallel + Options (Just Touch)', async () => {
       const results = await inspectPoku(
         isWindows
-          ? '--parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" test/integration/import.test.ts --filter=".test.|.spec."'
-          : '--parallel --concurrency=4 --platform=node --fast-fail --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 test/integration/import.test.ts --filter=.test.|.spec.'
+          ? '--parallel --concurrency=4 --platform=node --fail-fast --debug --exclude=".bak" --kill-port=4000 --kill-range="4000-4001" test/integration/import.test.ts --filter=".test.|.spec."'
+          : '--parallel --concurrency=4 --platform=node --fail-fast --debug --exclude=.bak --kill-port=4000 --kill-range=4000-4001 test/integration/import.test.ts --filter=.test.|.spec.'
       );
 
       console.log(results.stdout);
@@ -111,6 +111,7 @@ test(async () => {
       const exitCode = await poku('test/unit', {
         platform: 'node',
         parallel: true,
+        concurrency: 4,
         exclude: [/watch/, /map-tests/],
         noExit: true,
       });
@@ -125,7 +126,6 @@ test(async () => {
           platform: 'node',
           parallel: true,
           debug: true,
-          concurrency: 4,
           filter: /\.(test|spec)\./,
           failFast: true,
           noExit: true,

--- a/test/e2e/fail-fast.test.ts
+++ b/test/e2e/fail-fast.test.ts
@@ -5,8 +5,6 @@ import { inspectPoku, isBuild } from '../__utils__/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';
 import { nodeVersion } from '../../src/parsers/get-runtime.js';
 
-// TODO: fix exit code when using failFast
-
 if (isBuild || (nodeVersion && nodeVersion < 16)) {
   skip();
 }
@@ -22,7 +20,7 @@ describe('Fast Fast', async () => {
       console.log(results.stderr);
     }
 
-    // assert.strictEqual(results.exitCode, 1, 'Failed');
+    assert.strictEqual(results.exitCode, 1, 'Failed');
     assert.match(results.stderr, /fail-fast/, 'Fail Fast is enabled');
     assert.match(results.stdout, /FAIL › 1/, 'Needs to fail 1');
   });
@@ -37,7 +35,7 @@ describe('Fast Fast', async () => {
       console.log(results.stderr);
     }
 
-    // assert.strictEqual(results.exitCode, 1, 'Failed');
+    assert.strictEqual(results.exitCode, 1, 'Failed');
     assert.match(results.stdout, /fail-fast/, 'Fail Fast is enabled');
     assert.match(results.stdout, /FAIL › 1/, 'Needs to fail 1');
   });


### PR DESCRIPTION
After [v2.4.2](https://github.com/wellwelwel/poku/releases/tag/v2.4.2), when a test fails using the `fail-fast` option, the output is properly reported, but the exit code isn't propagated to process.
