### PR TITLE
fix(waitForPort): ensure process exit after Bun `v1.1.23`

### DIFF
--- a/.github/workflows/ci_compatibility-bun.yml
+++ b/.github/workflows/ci_compatibility-bun.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: ['1.1.22']
+        bun-version: ['latest', 'canary']
     name: Bun ${{ matrix.bun-version }}
     steps:
       - name: ➕ Actions - Checkout

--- a/src/modules/helpers/wait-for.ts
+++ b/src/modules/helpers/wait-for.ts
@@ -10,7 +10,7 @@ const checkPort = (port: number, host: string): Promise<boolean> =>
     const client = createConnection(port, host);
 
     client.on('connect', () => {
-      client.destroy();
+      client.end();
       resolve(true);
     });
 


### PR DESCRIPTION
After **Bun** `v1.1.23`, for some reason the tests no longer finish.

Checking if the problem has been solved.