### PR TITLE
feat: add `skip` modifier to `describe`, `it` and `test` methods

### DIFF
--- a/src/modules/helpers/describe.ts
+++ b/src/modules/helpers/describe.ts
@@ -4,6 +4,7 @@ import { format } from '../../services/format.js';
 import { Write } from '../../services/write.js';
 import { indentation } from '../../configs/indentation.js';
 import { todo } from './it/todo.js';
+import { skip } from './it/skip.js';
 
 async function describeCore(
   title: string,
@@ -71,4 +72,5 @@ async function describeCore(
 
 export const describe = Object.assign(describeCore, {
   todo,
+  skip,
 });

--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -4,6 +4,7 @@ import { indentation } from '../../../configs/indentation.js';
 import { format } from '../../../services/format.js';
 import { Write } from '../../../services/write.js';
 import { todo } from './todo.js';
+import { skip } from './skip.js';
 
 async function itCore(
   message: string,
@@ -82,4 +83,5 @@ async function itCore(
 
 export const it = Object.assign(itCore, {
   todo,
+  skip,
 });

--- a/src/modules/helpers/it/skip.ts
+++ b/src/modules/helpers/it/skip.ts
@@ -1,0 +1,8 @@
+import { Write } from '../../../services/write.js';
+import { indentation } from '../../../configs/indentation.js';
+import { format } from '../../../services/format.js';
+
+export const skip = (message: string, _cb?: () => unknown) =>
+  Write.log(
+    `${indentation.hasDescribe ? '  ' : ''}${format(`◯ ${message}`).info().bold()}`
+  );

--- a/test/__fixtures__/e2e/final-results/skip-describe-it/skip.test.ts
+++ b/test/__fixtures__/e2e/final-results/skip-describe-it/skip.test.ts
@@ -1,0 +1,9 @@
+import { exit } from 'node:process';
+import { describe } from '../../../../../src/modules/helpers/describe.js';
+import { it } from '../../../../../src/modules/helpers/it/core.js';
+
+describe('Dont skip', () => {
+  it.skip('Mixed skips in the same file should not be counted', () => {
+    exit(1);
+  });
+});

--- a/test/__fixtures__/e2e/final-results/skip-describe/skip.test.ts
+++ b/test/__fixtures__/e2e/final-results/skip-describe/skip.test.ts
@@ -1,0 +1,15 @@
+import { exit } from 'node:process';
+import { describe } from '../../../../../src/modules/helpers/describe.js';
+import { it } from '../../../../../src/modules/helpers/it/core.js';
+
+describe.skip('Some skip', () => {
+  exit(1);
+});
+
+describe.skip('Multiple skips in the same file should not be counted', () => {
+  exit(1);
+});
+
+it.skip('Mixed skips in the same file should not be counted', () => {
+  exit(1);
+});

--- a/test/__fixtures__/e2e/final-results/skip-it/skip.test.ts
+++ b/test/__fixtures__/e2e/final-results/skip-it/skip.test.ts
@@ -1,0 +1,10 @@
+import { exit } from 'node:process';
+import { it } from '../../../../../src/modules/helpers/it/core.js';
+
+it.skip('Some skip', () => {
+  exit(1);
+});
+
+it.skip('Multiple skips in the same file should not be counted', () => {
+  exit(1);
+});

--- a/test/__fixtures__/e2e/final-results/skip/skip.test.ts
+++ b/test/__fixtures__/e2e/final-results/skip/skip.test.ts
@@ -1,3 +1,5 @@
+import { exit } from 'node:process';
 import { skip } from '../../../../../src/modules/helpers/skip.js';
 
 skip('Some skip');
+exit(1);

--- a/test/e2e/final-results.test.ts
+++ b/test/e2e/final-results.test.ts
@@ -20,6 +20,36 @@ describe('Final Results', async () => {
     assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
   });
 
+  await it('Skip (it)', async () => {
+    const results = await inspectPoku('', {
+      cwd: 'test/__fixtures__/e2e/final-results/skip-it',
+    });
+
+    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
+    assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
+  });
+
+  await it('Skip (describe)', async () => {
+    const results = await inspectPoku('', {
+      cwd: 'test/__fixtures__/e2e/final-results/skip-describe',
+    });
+
+    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
+    assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
+  });
+
+  await it('Skip (describe + it)', async () => {
+    const results = await inspectPoku('', {
+      cwd: 'test/__fixtures__/e2e/final-results/skip-describe-it',
+    });
+
+    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
+    assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
+  });
+
   await it('Todo', async () => {
     const results = await inspectPoku('', {
       cwd: 'test/__fixtures__/e2e/final-results/todo',

--- a/website/docs/documentation/helpers/skip.mdx
+++ b/website/docs/documentation/helpers/skip.mdx
@@ -1,10 +1,13 @@
 ---
 sidebar_position: 4
+tags: [modifiers, debugging]
 ---
 
 # ⏭️ skip
 
-You can skip tests when necessary:
+## Skipping a test file
+
+You can skip test files when necessary:
 
 ```ts
 import { skip } from 'poku';
@@ -26,7 +29,7 @@ This will skip the entire file and it's recommended to be used at the top of the
 
 ---
 
-## Examples
+### Examples
 
 Imagine that a specific test doesn't work on a specific _OS_:
 
@@ -51,3 +54,29 @@ test(() => {
 :::note
 Skipped tests are considered successful tests.
 :::
+
+---
+
+## `describe`, `it` and `test` modifier
+
+To assist in the debugging process, you can modify your tests by temporarily skipping specific tests:
+
+```ts
+import { describe, it } from 'poku';
+
+describe(() => {
+  it('Running this', () => {
+    // I'll be executed
+  });
+
+  it.skip('Skipping for some reason', () => {
+    // I won't be executed
+  });
+});
+```
+
+Supports:
+
+- `describe.skip`
+- `it.skip`
+- `test.skip`


### PR DESCRIPTION
Related:

- #722