### PR TITLE
fix: improve counter output when using `skip` or `todo`

### DIFF
--- a/src/modules/helpers/exit.ts
+++ b/src/modules/helpers/exit.ts
@@ -9,7 +9,7 @@ import { AssertionError } from 'node:assert';
 
 export const exit = (code: Code, quiet?: boolean) => {
   const isPoku = results.success > 0 || results.fail > 0;
-  const success = ` PASS › ${results.success - results.skip || 0} `;
+  const success = ` PASS › ${results.success} `;
   const failure = ` FAIL › ${results.fail} `;
   const skips = ` SKIP › ${results.skip} `;
   const plans = ` TODO › ${results.todo} `;

--- a/src/parsers/output.ts
+++ b/src/parsers/output.ts
@@ -3,8 +3,8 @@ import { results } from '../configs/poku.js';
 
 const regex = {
   ansi: /u001b\[0m|\n/i,
-  skip: /\\u001b\[94m\\u001b\[1m◯/i,
-  todo: /\\u001b\[96m\\u001b\[1m●/i,
+  skip: /\\u001b\[94m\\u001b\[1m◯/gi,
+  todo: /\\u001b\[96m\\u001b\[1m●/gi,
 } as const;
 
 export const isQuiet = (configs?: Configs): boolean =>
@@ -20,8 +20,11 @@ export const parserOutput = (options: {
   const { output, result, configs } = options;
   const normalizedOutput = JSON.stringify(output);
 
-  if (regex.skip.test(normalizedOutput)) ++results.skip;
-  if (regex.todo.test(normalizedOutput)) ++results.todo;
+  const hasSkip = normalizedOutput.match(regex.skip);
+  if (hasSkip) results.skip += hasSkip.length;
+
+  const hasTodo = normalizedOutput.match(regex.todo);
+  if (hasTodo) results.todo += hasTodo.length;
 
   const debug = isDebug(configs);
   const pad = configs?.parallel ? '  ' : '    ';

--- a/test/e2e/final-results.test.ts
+++ b/test/e2e/final-results.test.ts
@@ -15,7 +15,7 @@ describe('Final Results', async () => {
       cwd: 'test/__fixtures__/e2e/final-results/skip',
     });
 
-    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
     assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
     assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
   });
@@ -25,9 +25,9 @@ describe('Final Results', async () => {
       cwd: 'test/__fixtures__/e2e/final-results/skip-it',
     });
 
-    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
     assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
-    assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
+    assert.match(results.stdout, /SKIP › 2/, 'Needs to skip 2');
   });
 
   await it('Skip (describe)', async () => {
@@ -35,9 +35,9 @@ describe('Final Results', async () => {
       cwd: 'test/__fixtures__/e2e/final-results/skip-describe',
     });
 
-    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
     assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
-    assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
+    assert.match(results.stdout, /SKIP › 3/, 'Needs to skip 3');
   });
 
   await it('Skip (describe + it)', async () => {
@@ -45,7 +45,7 @@ describe('Final Results', async () => {
       cwd: 'test/__fixtures__/e2e/final-results/skip-describe-it',
     });
 
-    assert.match(results.stdout, /PASS › 0/, 'Needs to pass 0');
+    assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
     assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
     assert.match(results.stdout, /SKIP › 1/, 'Needs to skip 1');
   });
@@ -65,7 +65,7 @@ describe('Final Results', async () => {
       cwd: 'test/__fixtures__/e2e/final-results/skip-and-todo',
     });
 
-    assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
+    assert.match(results.stdout, /PASS › 2/, 'Needs to pass 2');
     assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
     assert.match(results.stdout, /SKIP › 1/, 'Needs to todo 1');
     assert.match(results.stdout, /TODO › 1/, 'Needs to todo 1');
@@ -81,7 +81,7 @@ describe('Final Results', async () => {
       console.log(results.stderr);
     }
 
-    assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
+    assert.match(results.stdout, /PASS › 2/, 'Needs to pass 2');
     assert.match(results.stdout, /FAIL › 1/, 'Needs to fail 1');
     assert.match(results.stdout, /SKIP › 1/, 'Needs to todo 1');
     assert.match(results.stdout, /TODO › 1/, 'Needs to todo 1');

--- a/website/docs/documentation/helpers/skip.mdx
+++ b/website/docs/documentation/helpers/skip.mdx
@@ -27,6 +27,10 @@ skip('Skipping for some reason');
 This will skip the entire file and it's recommended to be used at the top of the test file.
 :::
 
+:::note
+Skipped tests are considered successful tests and don't affect the file test count.
+:::
+
 ---
 
 ### Examples
@@ -50,10 +54,6 @@ test(() => {
 });
 // highlight-end
 ```
-
-:::note
-Skipped tests are considered successful tests.
-:::
 
 ---
 
@@ -80,3 +80,7 @@ Supports:
 - `describe.skip`
 - `it.skip`
 - `test.skip`
+
+:::note
+Skipped tests are considered successful tests and don't affect the file test count.
+:::

--- a/website/docs/documentation/helpers/todo.mdx
+++ b/website/docs/documentation/helpers/todo.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 10
-tags: [boilerplate]
+tags: [modifiers, debugging]
 ---
 
 # 📋 todo
@@ -57,5 +57,8 @@ describe.todo('todo: Upcoming test', () => {
 <hr />
 
 :::note
-When using `beforeEach` or `afterEach`, they will not be triggered by tests with `.todo`.
+
+- When using `beforeEach` or `afterEach`, they will not be triggered by tests with `.todo`.
+- Skipped tests are considered successful tests and don't affect the file test count.
+
 :::


### PR DESCRIPTION
Closes #737.