### PR TITLE
ci: Deno v2 doesn't support `.cts` extension

### DIFF
--- a/test/e2e/runners.test.ts
+++ b/test/e2e/runners.test.ts
@@ -74,11 +74,16 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
   hasDeno &&
     (await it('Deno', async () => {
       const output = await inspectCLI(
-        'deno run --unstable-sloppy-imports --allow-read --allow-env --allow-run src/bin/index.ts --platform=deno test/__fixtures__/e2e/extensions --exclude=cts'
+        'deno run --unstable-sloppy-imports --allow-read --allow-env --allow-run src/bin/index.ts --platform=deno test/__fixtures__/e2e/extensions -d --exclude=.cts'
       );
 
+      if (output.exitCode !== 0) {
+        console.log(output.stdout);
+        console.log(output.stderr);
+      }
+
       assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
-      assert(/PASS › 12/.test(output.stdout), 'CLI needs to pass 1');
+      assert(/PASS › 10/.test(output.stdout), 'CLI needs to pass 1');
       assert(/FAIL › 0/.test(output.stdout), 'CLI needs to fail 0');
       assert(/deno run.+?.js/.test(output.stdout), 'deno => .js');
       assert(/deno run.+?.cjs/.test(output.stdout), 'deno => .cjs');

--- a/test/e2e/runners.test.ts
+++ b/test/e2e/runners.test.ts
@@ -40,8 +40,13 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
   hasNode &&
     (await it('Node.js', async () => {
       const output = await inspectCLI(
-        'npx tsx src/bin/index.ts --platform=node test/__fixtures__/e2e/extensions'
+        'npx tsx src/bin/index.ts --platform=node test/__fixtures__/e2e/extensions -d'
       );
+
+      if (output.exitCode !== 0) {
+        console.log(output.stdout);
+        console.log(output.stderr);
+      }
 
       assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
       assert(/PASS › 12/.test(output.stdout), 'CLI needs to pass 1');
@@ -57,8 +62,13 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
   hasBun &&
     (await it('Bun', async () => {
       const output = await inspectCLI(
-        'bun src/bin/index.ts --platform=bun test/__fixtures__/e2e/extensions'
+        'bun src/bin/index.ts --platform=bun test/__fixtures__/e2e/extensions -d'
       );
+
+      if (output.exitCode !== 0) {
+        console.log(output.stdout);
+        console.log(output.stderr);
+      }
 
       assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
       assert(/PASS › 12/.test(output.stdout), 'CLI needs to pass 1');

--- a/test/e2e/runners.test.ts
+++ b/test/e2e/runners.test.ts
@@ -74,7 +74,7 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
   hasDeno &&
     (await it('Deno', async () => {
       const output = await inspectCLI(
-        'deno run --unstable-sloppy-imports --allow-read --allow-env --allow-run src/bin/index.ts --platform=deno test/__fixtures__/e2e/extensions'
+        'deno run --unstable-sloppy-imports --allow-read --allow-env --allow-run src/bin/index.ts --platform=deno test/__fixtures__/e2e/extensions --exclude=cts'
       );
 
       assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
@@ -84,7 +84,7 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
       assert(/deno run.+?.cjs/.test(output.stdout), 'deno => .cjs');
       assert(/deno run.+?.mjs/.test(output.stdout), 'deno => .mjs');
       assert(/deno run.+?.ts/.test(output.stdout), 'deno => .ts');
-      assert(/deno run.+?.cts/.test(output.stdout), 'deno => .cts');
+      // assert(/deno run.+?.cts/.test(output.stdout), 'deno => .cts');
       assert(/deno run.+?.mts/.test(output.stdout), 'deno => .mts');
     }));
 });


### PR DESCRIPTION
Related:

- https://github.com/denoland/deno/issues/25498.

> Waiting for the resolution of the issue cited to decide if these tests should indeed be removed or if it's a temporary bug.
