### PR TITLE
fix: allow all combinations of `describe`, `it` and `test` to `skip` modifier

### DIFF
--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -7,7 +7,16 @@ export const todo = (message: string, _cb?: () => unknown) =>
     `${indentation.hasDescribe ? '  ' : ''}${format(`● ${message}`).cyan().bold()}`
   );
 
-export const skip = (message: string, _cb?: () => unknown) =>
+export function skip(message: string, _cb: () => unknown): void;
+export function skip(_cb: () => unknown): void;
+export function skip(
+  messageOrCb: string | (() => unknown),
+  _cb?: () => unknown
+) {
+  const message =
+    (typeof messageOrCb === 'string' && messageOrCb) || 'Skipping';
+
   Write.log(
     `${indentation.hasDescribe ? '  ' : ''}${format(`◯ ${message}`).info().bold()}`
   );
+}

--- a/test/__fixtures__/e2e/final-results/skip-it/skip.test.ts
+++ b/test/__fixtures__/e2e/final-results/skip-it/skip.test.ts
@@ -8,3 +8,7 @@ it.skip('Some skip', () => {
 it.skip('Multiple skips in the same file should not be counted', () => {
   exit(1);
 });
+
+it.skip(() => {
+  exit(1);
+});

--- a/test/e2e/final-results.test.ts
+++ b/test/e2e/final-results.test.ts
@@ -27,7 +27,9 @@ describe('Final Results', async () => {
 
     assert.match(results.stdout, /PASS › 1/, 'Needs to pass 1');
     assert.match(results.stdout, /FAIL › 0/, 'Needs to fail 0');
-    assert.match(results.stdout, /SKIP › 2/, 'Needs to skip 2');
+    assert.match(results.stdout, /SKIP › 3/, 'Needs to skip 3');
+    assert.match(results.stdout, /◯ Some skip/, 'User Messsage');
+    assert.match(results.stdout, /◯ Skipping/, 'No Messsage');
   });
 
   await it('Skip (describe)', async () => {


### PR DESCRIPTION
Fixes: https://github.com/wellwelwel/poku/commit/b756605142ec2a1a22d5fe46d2f62aade2812d51#r146279295