### PR TITLE
refactor: remove redundant code

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,123 +1,133 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.2/schema.json",
-  "files": {
-    "include": ["**/**"],
-    "ignore": [
-      "benchmark",
-      "ci",
-      "coverage",
-      "lib",
-      "node_modules",
-      "test/__fixtures__",
-      "website"
-    ]
-  },
-  "organizeImports": {
-    "enabled": false
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "all": true,
-      "complexity": {
-        "all": true,
-        "noExcessiveCognitiveComplexity": {
-          "level": "error",
-          "options": {
-            // TODO: better estimate complexity
-            "maxAllowedComplexity": 45
-          }
-        }
-      },
-      "a11y": {
-        "all": true
-      },
-      "correctness": {
-        "all": true,
-        "noNodejsModules": "off"
-      },
-      "nursery": {
-        "all": true,
-        "useImportRestrictions": "off",
-        "noConsole": "off",
-        "noMisplacedAssertion": "off",
-        "useImportExtensions": "error"
-      },
-      "performance": {
-        "all": true,
-        "noAccumulatingSpread": "error",
-        "noBarrelFile": "error",
-        "noDelete": "error",
-        "noReExportAll": "error"
-      },
-      "security": {
-        "all": true,
-        "noGlobalEval": "error"
-      },
-      "suspicious": {
-        "all": true,
-        "noEmptyBlockStatements": "off",
-        "noConsoleLog": "off",
-        "noAsyncPromiseExecutor": "error",
-        "useAwait": "error",
-        "useIsArray": "error"
-      },
-      "style": {
-        "all": true,
-        "noNonNullAssertion": "off",
-        "useNamingConvention": "off",
-        "useNodeAssertStrict": "off",
-        "noNamespaceImport": "off",
-        "useBlockStatements": "off"
-      }
-    }
-  },
-  "javascript": {
-    "globals": ["BufferEncoding"]
-  },
-  "overrides": [
-    {
-      "include": ["test", "tools"],
-      "linter": {
-        "rules": {
-          "nursery": {
-            "useTopLevelRegex": "off"
-          },
-          "complexity": {
-            "useArrowFunction": "off"
-          }
-        }
-      }
-    },
-    {
-      "include": ["src/polyfills/**/**"],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noExplicitAny": "off"
-          }
-        }
-      }
-    },
-    {
-      "include": ["src/modules/index.ts"],
-      "linter": {
-        "rules": {
-          "performance": {
-            "noBarrelFile": "off"
-          }
-        }
-      }
-    },
-    {
-      "include": ["src/bin/index.ts"],
-      "linter": {
-        "rules": {
-          "complexity": {
-            "noExcessiveCognitiveComplexity": "off"
-          }
-        }
-      }
-    }
-  ]
+	"$schema": "https://biomejs.dev/schemas/1.8.2/schema.json",
+	"files": {
+		"include": ["**/**"],
+		"ignore": [
+			"benchmark",
+			"ci",
+			"coverage",
+			"lib",
+			"node_modules",
+			"test/__fixtures__",
+			"website"
+		]
+	},
+	"organizeImports": {
+		"enabled": false
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"all": true,
+			"complexity": {
+				"all": true,
+				"noExcessiveCognitiveComplexity": {
+					"level": "error",
+					"options": {
+						// TODO: better estimate complexity
+						"maxAllowedComplexity": 45
+					}
+				}
+			},
+			"a11y": {
+				"all": true
+			},
+			"correctness": {
+				"all": true,
+				"noNodejsModules": "off"
+			},
+			"nursery": {
+				"all": true,
+				"useImportRestrictions": "off",
+				"noConsole": "off",
+				"noMisplacedAssertion": "off",
+				"useImportExtensions": "error"
+			},
+			"performance": {
+				"all": true,
+				"noAccumulatingSpread": "error",
+				"noBarrelFile": "error",
+				"noDelete": "error",
+				"noReExportAll": "error"
+			},
+			"security": {
+				"all": true,
+				"noGlobalEval": "error"
+			},
+			"suspicious": {
+				"all": true,
+				"noEmptyBlockStatements": "off",
+				"noConsoleLog": "off",
+				"noAsyncPromiseExecutor": "error",
+				"useAwait": "error",
+				"useIsArray": "error"
+			},
+			"style": {
+				"all": true,
+				"noNonNullAssertion": "off",
+				"useNamingConvention": "off",
+				"useNodeAssertStrict": "off",
+				"noNamespaceImport": "off",
+				"useBlockStatements": "off"
+			}
+		}
+	},
+	"javascript": {
+		"globals": ["BufferEncoding"]
+	},
+	"overrides": [
+		{
+			"include": ["test", "tools"],
+			"linter": {
+				"rules": {
+					"nursery": {
+						"useTopLevelRegex": "off"
+					},
+					"complexity": {
+						"useArrowFunction": "off"
+					}
+				}
+			}
+		},
+		{
+			"include": ["src/polyfills/**/**"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noExplicitAny": "off"
+					}
+				}
+			}
+		},
+		{
+			"include": ["src/modules/index.ts"],
+			"linter": {
+				"rules": {
+					"performance": {
+						"noBarrelFile": "off"
+					}
+				}
+			}
+		},
+		{
+			"include": ["src/modules/helpers/modifiers.ts"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"useAwait": "off"
+					}
+				}
+			}
+		},
+		{
+			"include": ["src/bin/index.ts"],
+			"linter": {
+				"rules": {
+					"complexity": {
+						"noExcessiveCognitiveComplexity": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,133 +1,133 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.8.2/schema.json",
-	"files": {
-		"include": ["**/**"],
-		"ignore": [
-			"benchmark",
-			"ci",
-			"coverage",
-			"lib",
-			"node_modules",
-			"test/__fixtures__",
-			"website"
-		]
-	},
-	"organizeImports": {
-		"enabled": false
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"all": true,
-			"complexity": {
-				"all": true,
-				"noExcessiveCognitiveComplexity": {
-					"level": "error",
-					"options": {
-						// TODO: better estimate complexity
-						"maxAllowedComplexity": 45
-					}
-				}
-			},
-			"a11y": {
-				"all": true
-			},
-			"correctness": {
-				"all": true,
-				"noNodejsModules": "off"
-			},
-			"nursery": {
-				"all": true,
-				"useImportRestrictions": "off",
-				"noConsole": "off",
-				"noMisplacedAssertion": "off",
-				"useImportExtensions": "error"
-			},
-			"performance": {
-				"all": true,
-				"noAccumulatingSpread": "error",
-				"noBarrelFile": "error",
-				"noDelete": "error",
-				"noReExportAll": "error"
-			},
-			"security": {
-				"all": true,
-				"noGlobalEval": "error"
-			},
-			"suspicious": {
-				"all": true,
-				"noEmptyBlockStatements": "off",
-				"noConsoleLog": "off",
-				"noAsyncPromiseExecutor": "error",
-				"useAwait": "error",
-				"useIsArray": "error"
-			},
-			"style": {
-				"all": true,
-				"noNonNullAssertion": "off",
-				"useNamingConvention": "off",
-				"useNodeAssertStrict": "off",
-				"noNamespaceImport": "off",
-				"useBlockStatements": "off"
-			}
-		}
-	},
-	"javascript": {
-		"globals": ["BufferEncoding"]
-	},
-	"overrides": [
-		{
-			"include": ["test", "tools"],
-			"linter": {
-				"rules": {
-					"nursery": {
-						"useTopLevelRegex": "off"
-					},
-					"complexity": {
-						"useArrowFunction": "off"
-					}
-				}
-			}
-		},
-		{
-			"include": ["src/polyfills/**/**"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noExplicitAny": "off"
-					}
-				}
-			}
-		},
-		{
-			"include": ["src/modules/index.ts"],
-			"linter": {
-				"rules": {
-					"performance": {
-						"noBarrelFile": "off"
-					}
-				}
-			}
-		},
-		{
-			"include": ["src/modules/helpers/modifiers.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"useAwait": "off"
-					}
-				}
-			}
-		},
-		{
-			"include": ["src/bin/index.ts"],
-			"linter": {
-				"rules": {
-					"complexity": {
-						"noExcessiveCognitiveComplexity": "off"
-					}
-				}
-			}
-		}
-	]
+  "$schema": "https://biomejs.dev/schemas/1.8.2/schema.json",
+  "files": {
+    "include": ["**/**"],
+    "ignore": [
+      "benchmark",
+      "ci",
+      "coverage",
+      "lib",
+      "node_modules",
+      "test/__fixtures__",
+      "website"
+    ]
+  },
+  "organizeImports": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "all": true,
+      "complexity": {
+        "all": true,
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            // TODO: better estimate complexity
+            "maxAllowedComplexity": 45
+          }
+        }
+      },
+      "a11y": {
+        "all": true
+      },
+      "correctness": {
+        "all": true,
+        "noNodejsModules": "off"
+      },
+      "nursery": {
+        "all": true,
+        "useImportRestrictions": "off",
+        "noConsole": "off",
+        "noMisplacedAssertion": "off",
+        "useImportExtensions": "error"
+      },
+      "performance": {
+        "all": true,
+        "noAccumulatingSpread": "error",
+        "noBarrelFile": "error",
+        "noDelete": "error",
+        "noReExportAll": "error"
+      },
+      "security": {
+        "all": true,
+        "noGlobalEval": "error"
+      },
+      "suspicious": {
+        "all": true,
+        "noEmptyBlockStatements": "off",
+        "noConsoleLog": "off",
+        "noAsyncPromiseExecutor": "error",
+        "useAwait": "error",
+        "useIsArray": "error"
+      },
+      "style": {
+        "all": true,
+        "noNonNullAssertion": "off",
+        "useNamingConvention": "off",
+        "useNodeAssertStrict": "off",
+        "noNamespaceImport": "off",
+        "useBlockStatements": "off"
+      }
+    }
+  },
+  "javascript": {
+    "globals": ["BufferEncoding"]
+  },
+  "overrides": [
+    {
+      "include": ["test", "tools"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "useTopLevelRegex": "off"
+          },
+          "complexity": {
+            "useArrowFunction": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/polyfills/**/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/modules/index.ts"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noBarrelFile": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/modules/helpers/modifiers.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "useAwait": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["src/bin/index.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -8,7 +8,6 @@ export async function todo(
   cb?: () => Promise<unknown>
 ): Promise<void>;
 export function todo(message: string, cb?: () => unknown): void;
-// biome-ignore lint/suspicious/useAwait: <TODO explanation>
 export async function todo(
   message: string | (() => unknown) | (() => Promise<unknown>),
   _cb?: (() => unknown) | (() => Promise<unknown>)
@@ -25,13 +24,11 @@ export async function skip(
 export function skip(message: string, cb: () => unknown): void;
 export async function skip(cb: () => Promise<unknown>): Promise<void>;
 export function skip(cb: () => unknown): void;
-// biome-ignore lint/suspicious/useAwait: <TODO explanation>
 export async function skip(
   messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
   _cb?: (() => unknown) | (() => Promise<unknown>)
 ): Promise<void> {
-  const message =
-    (typeof messageOrCb === 'string' && messageOrCb) || 'Skipping';
+  const message = typeof messageOrCb === 'string' ? messageOrCb : 'Skipping';
 
   Write.log(
     `${indentation.hasDescribe ? '  ' : ''}${format(`◯ ${message}`).info().bold()}`

--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -8,6 +8,7 @@ export async function todo(
   cb?: () => Promise<unknown>
 ): Promise<void>;
 export function todo(message: string, cb?: () => unknown): void;
+// biome-ignore lint/suspicious/useAwait: <TODO explanation>
 export async function todo(
   message: string | (() => unknown) | (() => Promise<unknown>),
   _cb?: (() => unknown) | (() => Promise<unknown>)
@@ -24,6 +25,7 @@ export async function skip(
 export function skip(message: string, cb: () => unknown): void;
 export async function skip(cb: () => Promise<unknown>): Promise<void>;
 export function skip(cb: () => unknown): void;
+// biome-ignore lint/suspicious/useAwait: <TODO explanation>
 export async function skip(
   messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
   _cb?: (() => unknown) | (() => Promise<unknown>)

--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -5,9 +5,9 @@ import { format } from '../../services/format.js';
 export function todo(message: string): void;
 export async function todo(
   message: string,
-  _cb?: () => Promise<unknown>
+  cb?: () => Promise<unknown>
 ): Promise<void>;
-export function todo(message: string, _cb?: () => unknown): void;
+export function todo(message: string, cb?: () => unknown): void;
 export async function todo(
   message: string | (() => unknown) | (() => Promise<unknown>),
   _cb?: (() => unknown) | (() => Promise<unknown>)
@@ -15,24 +15,15 @@ export async function todo(
   Write.log(
     `${indentation.hasDescribe ? '  ' : ''}${format(`● ${message}`).cyan().bold()}`
   );
-
-  /* c8 ignore start */ // Type guard
-  if (typeof _cb === 'function') {
-    const isAsync = _cb.constructor.name === 'AsyncFunction';
-
-    if (isAsync) return await Promise.resolve();
-    return;
-  }
-  /* c8 ignore stop */
 }
 
 export async function skip(
   message: string,
-  _cb: () => Promise<unknown>
+  cb: () => Promise<unknown>
 ): Promise<void>;
-export function skip(message: string, _cb: () => unknown): void;
-export async function skip(_cb: () => Promise<unknown>): Promise<void>;
-export function skip(_cb: () => unknown): void;
+export function skip(message: string, cb: () => unknown): void;
+export async function skip(cb: () => Promise<unknown>): Promise<void>;
+export function skip(cb: () => unknown): void;
 export async function skip(
   messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
   _cb?: (() => unknown) | (() => Promise<unknown>)
@@ -43,20 +34,4 @@ export async function skip(
   Write.log(
     `${indentation.hasDescribe ? '  ' : ''}${format(`◯ ${message}`).info().bold()}`
   );
-
-  /* c8 ignore start */ // Type guard
-  if (typeof messageOrCb === 'function') {
-    const isAsync = messageOrCb.constructor.name === 'AsyncFunction';
-
-    if (isAsync) return await Promise.resolve();
-    return;
-  }
-
-  if (typeof _cb === 'function') {
-    const isAsync = _cb.constructor.name === 'AsyncFunction';
-
-    if (isAsync) return await Promise.resolve();
-    return;
-  }
-  /* c8 ignore stop */
 }


### PR DESCRIPTION
It looks like by fixing typings some redundant code was added.

Might be I misunderstood something. On surface it looks like tests cannot reach these lines. So why to ship them to `npm`, if they do nothing?