### PR TITLE
feat(strict): use standard `assert` for Node.js legacy versions

### DIFF
--- a/src/modules/essentials/strict.ts
+++ b/src/modules/essentials/strict.ts
@@ -1,4 +1,10 @@
-import nodeAssert from 'node:assert/strict';
 import { createAssert } from '../../builders/assert.js';
+import { nodeVersion } from '../../parsers/get-runtime.js';
+
+/* c8 ignore next 4 */ // Platform version
+const nodeAssert =
+  !nodeVersion || nodeVersion >= 16
+    ? require('node:assert/strict')
+    : require('node:assert');
 
 export const strict = createAssert(nodeAssert);

--- a/test/e2e/before-and-after-each.test.ts
+++ b/test/e2e/before-and-after-each.test.ts
@@ -1,15 +1,12 @@
-import { nodeVersion } from '../../src/parsers/get-runtime.js';
-import { skip } from '../../src/modules/helpers/skip.js';
-
-if (nodeVersion && nodeVersion < 16) {
-  skip();
-}
-
 import { test } from '../../src/modules/helpers/test.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { it } from '../../src/modules/helpers/it/core.js';
 import { poku } from '../../src/modules/essentials/poku.js';
 import { assert } from '../../src/modules/essentials/assert.js';
+import { getRuntime } from '../../src/parsers/get-runtime.js';
+import { skip } from '../../src/modules/helpers/skip.js';
+
+if (getRuntime() === 'deno') skip();
 
 test(async () => {
   const prepareService = () => new Promise((resolve) => resolve(undefined));

--- a/test/e2e/each-api-order.test.ts
+++ b/test/e2e/each-api-order.test.ts
@@ -1,14 +1,11 @@
-import { getRuntime, nodeVersion } from '../../src/parsers/get-runtime.js';
-import { skip } from '../../src/modules/helpers/skip.js';
-
-if (nodeVersion && nodeVersion < 16) {
-  skip();
-}
-
+import { getRuntime } from '../../src/parsers/get-runtime.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { ext, inspectPoku } from '../__utils__/capture-cli.test.js';
+import { skip } from '../../src/modules/helpers/skip.js';
+
+if (getRuntime() === 'deno') skip();
 
 const runtime = getRuntime();
 const offset = runtime === 'bun' ? 37 : 33;

--- a/test/e2e/fail-fast.test.ts
+++ b/test/e2e/fail-fast.test.ts
@@ -3,11 +3,9 @@ import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { inspectPoku, isBuild } from '../__utils__/capture-cli.test.js';
 import { skip } from '../../src/modules/helpers/skip.js';
-import { nodeVersion } from '../../src/parsers/get-runtime.js';
+import { getRuntime } from '../../src/parsers/get-runtime.js';
 
-if (isBuild || (nodeVersion && nodeVersion < 16)) {
-  skip();
-}
+if (isBuild || getRuntime() === 'deno') skip();
 
 describe('Fast Fast', async () => {
   await it('Parallel / Concurrent', async () => {

--- a/test/e2e/failure.test.ts
+++ b/test/e2e/failure.test.ts
@@ -1,14 +1,11 @@
-import { getRuntime, nodeVersion } from '../../src/parsers/get-runtime.js';
-import { skip } from '../../src/modules/helpers/skip.js';
-
-if (nodeVersion && nodeVersion < 16) {
-  skip();
-}
-
+import { getRuntime } from '../../src/parsers/get-runtime.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { inspectPoku, isBuild } from '../__utils__/capture-cli.test.js';
+import { skip } from '../../src/modules/helpers/skip.js';
+
+if (getRuntime() === 'deno') skip();
 
 describe('Failure', async () => {
   await it('Sequential', async () => {

--- a/test/integration/before-and-after-each/invalid.test.ts
+++ b/test/integration/before-and-after-each/invalid.test.ts
@@ -2,6 +2,10 @@ import { test } from '../../../src/modules/helpers/test.js';
 import { poku } from '../../../src/modules/essentials/poku.js';
 import { ext } from '../../__utils__/capture-cli.test.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
+import { getRuntime } from '../../../src/parsers/get-runtime.js';
+import { skip } from '../../../src/modules/helpers/skip.js';
+
+if (getRuntime() === 'deno') skip();
 
 test('Before and After Each: updating an external file', async () => {
   const prepareService = true;

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -1,40 +1,41 @@
+import { test } from '../../src/modules/helpers/test.js';
+import { getRuntime } from '../../src/parsers/get-runtime.js';
 import { skip } from '../../src/modules/helpers/skip.js';
-import { nodeVersion } from '../../src/parsers/get-runtime.js';
 
-if (nodeVersion && nodeVersion < 16) {
-  skip('Strict method is available from Node.js 16');
-}
+if (getRuntime() === 'deno') skip();
 
-import * as index from '../../src/modules/index.js';
+test(async () => {
+  const index = await import('../../src/modules/index.js');
 
-index.test('Import Suite', () => {
-  index.assert.ok(index.poku, 'Importing poku method');
-  index.assert.ok(index.assert, 'Importing assert method');
-  index.assert.ok(index.strict, 'Importing strict method');
+  index.test('Import Suite', () => {
+    index.assert.ok(index.poku, 'Importing poku method');
+    index.assert.ok(index.assert, 'Importing assert method');
+    index.assert.ok(index.strict, 'Importing strict method');
 
-  index.assert.ok(index.defineConfig, 'Importing defineConfig method');
-  index.assert.ok(index.envFile, 'Importing envFile method');
-  index.assert.ok(index.startService, 'Importing startService method');
-  index.assert.ok(index.startScript, 'Importing startScript method');
-  index.assert.ok(index.docker, 'Importing docker method');
-  index.assert.ok(index.getPIDs, 'Importing getPIDs helper');
-  index.assert.ok(index.kill, 'Importing kill helper');
-  index.assert.ok(index.describe, 'Importing describe helper');
-  index.assert.ok(index.beforeEach, 'Importing beforeEach helper');
-  index.assert.ok(index.afterEach, 'Importing afterEach helper');
-  index.assert.ok(index.log, 'Importing log helper');
-  index.assert.ok(index.test, 'Importing test helper');
-  index.assert.ok(index.skip, 'Importing skip helper');
-  index.assert.ok(index.sleep, 'Importing sleep helper');
-  index.assert.ok(
-    index.waitForExpectedResult,
-    'Importing waitForExpectedResult helper'
-  );
-  index.assert.ok(index.waitForPort, 'Importing waitForPort helper');
-  index.assert.ok(index.exit, 'Importing exit helper');
-  index.assert.ok(index.listFiles, 'Importing listFiles helper');
-  index.assert.ok(
-    typeof index.version === 'string',
-    'Importing listFiles helper'
-  );
+    index.assert.ok(index.defineConfig, 'Importing defineConfig method');
+    index.assert.ok(index.envFile, 'Importing envFile method');
+    index.assert.ok(index.startService, 'Importing startService method');
+    index.assert.ok(index.startScript, 'Importing startScript method');
+    index.assert.ok(index.docker, 'Importing docker method');
+    index.assert.ok(index.getPIDs, 'Importing getPIDs helper');
+    index.assert.ok(index.kill, 'Importing kill helper');
+    index.assert.ok(index.describe, 'Importing describe helper');
+    index.assert.ok(index.beforeEach, 'Importing beforeEach helper');
+    index.assert.ok(index.afterEach, 'Importing afterEach helper');
+    index.assert.ok(index.log, 'Importing log helper');
+    index.assert.ok(index.test, 'Importing test helper');
+    index.assert.ok(index.skip, 'Importing skip helper');
+    index.assert.ok(index.sleep, 'Importing sleep helper');
+    index.assert.ok(
+      index.waitForExpectedResult,
+      'Importing waitForExpectedResult helper'
+    );
+    index.assert.ok(index.waitForPort, 'Importing waitForPort helper');
+    index.assert.ok(index.exit, 'Importing exit helper');
+    index.assert.ok(index.listFiles, 'Importing listFiles helper');
+    index.assert.ok(
+      typeof index.version === 'string',
+      'Importing listFiles helper'
+    );
+  });
 });

--- a/test/integration/strict/assert-no-message.test.ts
+++ b/test/integration/strict/assert-no-message.test.ts
@@ -1,15 +1,20 @@
 import { skip } from '../../../src/modules/helpers/skip.js';
-import { nodeVersion } from '../../../src/parsers/get-runtime.js';
+import { getRuntime, nodeVersion } from '../../../src/parsers/get-runtime.js';
 
 if (nodeVersion && nodeVersion < 16) {
   skip('Strict method is available from Node.js 16');
 }
 
+if (getRuntime() === 'deno') skip();
+
 import { describe } from '../../../src/modules/helpers/describe.js';
 import { it } from '../../../src/modules/helpers/it/core.js';
-import { strict as assert } from '../../../src/modules/essentials/strict.js';
 
-describe('Strict Suite (No Message)', () => {
+describe('Strict Suite (No Message)', async () => {
+  const { strict: assert } = await import(
+    '../../../src/modules/essentials/strict.js'
+  );
+
   it(() => {
     assert(true);
     assert(1);

--- a/test/integration/strict/assert.test.ts
+++ b/test/integration/strict/assert.test.ts
@@ -1,15 +1,18 @@
 import { skip } from '../../../src/modules/helpers/skip.js';
-import { nodeVersion } from '../../../src/parsers/get-runtime.js';
+import { getRuntime, nodeVersion } from '../../../src/parsers/get-runtime.js';
 
-if (nodeVersion && nodeVersion < 16) {
+if ((nodeVersion && nodeVersion < 16) || getRuntime() === 'deno') {
   skip('Strict method is available from Node.js 16');
 }
 
 import { describe } from '../../../src/modules/helpers/describe.js';
 import { it } from '../../../src/modules/helpers/it/core.js';
-import { strict as assert } from '../../../src/modules/essentials/strict.js';
 
 describe('Strict Suite', async () => {
+  const { strict: assert } = await import(
+    '../../../src/modules/essentials/strict.js'
+  );
+
   it(() => {
     assert(true, 'ok (default) with true');
     assert(1, 'ok (default) with 1');

--- a/test/integration/strict/assert.test.ts
+++ b/test/integration/strict/assert.test.ts
@@ -1,12 +1,11 @@
-import { skip } from '../../../src/modules/helpers/skip.js';
+import { describe } from '../../../src/modules/helpers/describe.js';
+import { it } from '../../../src/modules/helpers/it/core.js';
 import { getRuntime, nodeVersion } from '../../../src/parsers/get-runtime.js';
+import { skip } from '../../../src/modules/helpers/skip.js';
 
 if ((nodeVersion && nodeVersion < 16) || getRuntime() === 'deno') {
   skip('Strict method is available from Node.js 16');
 }
-
-import { describe } from '../../../src/modules/helpers/describe.js';
-import { it } from '../../../src/modules/helpers/it/core.js';
 
 describe('Strict Suite', async () => {
   const { strict: assert } = await import(

--- a/test/integration/strict/ensure-strict.test.ts
+++ b/test/integration/strict/ensure-strict.test.ts
@@ -3,7 +3,7 @@ import { getRuntime, nodeVersion } from '../../../src/parsers/get-runtime.js';
 import { describe } from '../../../src/modules/helpers/describe.js';
 import { assert } from '../../../src/modules/essentials/assert.js';
 
-if ((nodeVersion && nodeVersion < 16) || getRuntime() === 'deno') {
+if ((nodeVersion && nodeVersion < 16) || getRuntime() !== 'node') {
   skip('Strict method is available from Node.js 16');
 }
 

--- a/test/integration/strict/ensure-strict.test.ts
+++ b/test/integration/strict/ensure-strict.test.ts
@@ -1,0 +1,20 @@
+import { skip } from '../../../src/modules/helpers/skip.js';
+import { getRuntime, nodeVersion } from '../../../src/parsers/get-runtime.js';
+import { describe } from '../../../src/modules/helpers/describe.js';
+import { assert } from '../../../src/modules/essentials/assert.js';
+
+if ((nodeVersion && nodeVersion < 16) || getRuntime() === 'deno') {
+  skip('Strict method is available from Node.js 16');
+}
+
+describe('Ensure strict', async () => {
+  const { strict } = await import('../../../src/modules/essentials/strict.js');
+
+  const actual = Object.create(null);
+  const expected = { name: 'John' };
+
+  actual.name = 'John';
+
+  assert.deepEqual(actual, expected);
+  strict.notDeepEqual(actual, expected);
+});

--- a/test/unit/define-configs.test.ts
+++ b/test/unit/define-configs.test.ts
@@ -1,15 +1,16 @@
-import { nodeVersion } from '../../src/parsers/get-runtime.js';
+import { test } from '../../src/modules/helpers/test.js';
+import { getRuntime } from '../../src/parsers/get-runtime.js';
 import { skip } from '../../src/modules/helpers/skip.js';
 
-if (nodeVersion && nodeVersion < 16) {
-  skip();
-}
+if (getRuntime() === 'deno') skip();
 
-import { assert } from '../../src/modules/essentials/assert.js';
-import { defineConfig } from '../../src/modules/index.js';
+test(async () => {
+  const { assert } = await import('../../src/modules/essentials/assert.js');
+  const { defineConfig } = await import('../../src/modules/index.js');
 
-assert.deepStrictEqual(
-  defineConfig({ debug: true }),
-  { debug: true },
-  'Reflect configs'
-);
+  assert.deepStrictEqual(
+    defineConfig({ debug: true }),
+    { debug: true },
+    'Reflect configs'
+  );
+});

--- a/website/docs/documentation/assert/index.mdx
+++ b/website/docs/documentation/assert/index.mdx
@@ -38,7 +38,7 @@ Strict assertions:
 + import { strict as assert } from 'poku';
 ```
 
-- `strict` method is available for **Node.js 16** onwards, **Bun**, and **Deno**.
+- `strict` method is available for **Node.js 16** onwards, **Bun**, and **Deno**. If you use it on unsupported **Node.js** versions, **Poku** will use the standard `assert` instead.
 
 ```ts
 assert(true, "It's true 🧪");


### PR DESCRIPTION
Fixes #760.

This approach avoids `MODULE_NOT_FOUND` in **Node.js** < 16. Instead, it uses the standard `assert`.

- No changes for **Bun** and **Deno**.
