### PR TITLE
migrate to node parse args

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
     "include": ["**/**"],
     "ignore": [

--- a/src/bin/watch.ts
+++ b/src/bin/watch.ts
@@ -5,7 +5,7 @@ import { Write } from '../services/write.js';
 import process from 'node:process';
 import type { Configs } from '../@types/poku.js';
 import { format } from '../services/format.js';
-import { getArg } from '../parsers/get-arg.js';
+import { values } from '../parsers/get-arg.js';
 import { fileResults } from '../configs/files.js';
 import { availableParallelism } from '../polyfills/os.js';
 
@@ -14,7 +14,7 @@ export const startWatch = async (dirs: string[], options: Configs) => {
 
   const watchers: Set<Watcher> = new Set();
   const executing = new Set<string>();
-  const interval = Number(getArg('watchinterval')) || 1500;
+  const interval = Number(values.watchinterval) || 1500;
 
   const setIsRunning = (value: boolean) => {
     isRunning = value;

--- a/src/modules/helpers/container.ts
+++ b/src/modules/helpers/container.ts
@@ -5,9 +5,9 @@ import type {
 import { DockerCompose, DockerContainer } from '../../services/container.js';
 
 /** A minimal API to assist tests that require containers or tests that run inside containers using a **Dockerfile**. */
-const dockerfile = (configs: DockerfileConfigs) => new DockerContainer(configs);
+const dockerfile = (configs: DockerfileConfigs): DockerContainer => new DockerContainer(configs);
 
 /** A minimal API to assist tests that require containers or tests that run inside containers using a **docker-compose.yml**. */
-const compose = (configs: DockerComposeConfigs) => new DockerCompose(configs);
+const compose = (configs: DockerComposeConfigs): DockerCompose => new DockerCompose(configs);
 
 export const docker = { dockerfile, compose };

--- a/src/modules/helpers/each.ts
+++ b/src/modules/helpers/each.ts
@@ -24,19 +24,19 @@ export const beforeEach = (
 ): Control => {
   options?.immediate && callback();
 
-  each.before.cb = () => {
+  each.before.cb = (): unknown => {
     if (each.before.status) return callback();
   };
 
-  const pause = () => {
+  const pause = (): void => {
     each.before.status = false;
   };
 
-  const continueFunc = () => {
+  const continueFunc = (): void => {
     each.before.status = true;
   };
 
-  const reset = () => {
+  const reset = (): void => {
     each.before.cb = undefined;
   };
 
@@ -61,19 +61,19 @@ export const beforeEach = (
  * ```
  */
 export const afterEach = (callback: () => unknown): Control => {
-  each.after.cb = () => {
+  each.after.cb = (): unknown => {
     if (each.after.status) return callback();
   };
 
-  const pause = () => {
+  const pause = (): void => {
     each.after.status = false;
   };
 
-  const continueFunc = () => {
+  const continueFunc = (): void => {
     each.after.status = true;
   };
 
-  const reset = () => {
+  const reset = (): void => {
     each.after.cb = undefined;
   };
 

--- a/src/modules/helpers/list-files.ts
+++ b/src/modules/helpers/list-files.ts
@@ -24,10 +24,10 @@ export const sanitizePath = (input: string, ensureTarget?: boolean): string => {
     : sanitizedPath;
 };
 
-export const isFile = async (fullPath: string) =>
+export const isFile = async (fullPath: string): Promise<boolean> =>
   (await fsStat(fullPath)).isFile();
 
-export const escapeRegExp = (string: string) =>
+export const escapeRegExp = (string: string): string =>
   string.replace(regex.safeRegExp, '\\$&');
 
 const envFilter = env.FILTER?.trim()

--- a/src/modules/helpers/log.ts
+++ b/src/modules/helpers/log.ts
@@ -2,7 +2,7 @@ import { parseResultType } from '../../parsers/assert.js';
 import { Write } from '../../services/write.js';
 
 /** By default **Poku** only shows outputs generated from itself. This helper allows you to use an alternative to `console.log` with **Poku**. */
-export const log = (...args: unknown[]) => {
+export const log = (...args: unknown[]): void => {
   const parsedMessages = args
     .map((arg) => parseResultType(arg))
     .join(' ')

--- a/src/modules/helpers/skip.ts
+++ b/src/modules/helpers/skip.ts
@@ -2,7 +2,7 @@ import { exit, env } from 'node:process';
 import { Write } from '../../services/write.js';
 import { format } from '../../services/format.js';
 
-export const skip = (message = 'Skipping') => {
+export const skip = (message = 'Skipping'): void => {
   const isPoku = typeof env?.FILE === 'string' && env?.FILE.length > 0;
   const FILE = env.FILE;
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -40,4 +40,4 @@ export type {
 export type { Configs as ListFilesConfigs } from '../@types/list-files.js';
 
 /** 🐷 Auxiliary function to define the `poku` configurations */
-export const defineConfig = (options: ConfigFile) => options;
+export const defineConfig = (options: ConfigFile): ConfigFile => options;

--- a/src/parsers/time.ts
+++ b/src/parsers/time.ts
@@ -1,4 +1,4 @@
-const pad = (num: number) => String(num).padStart(2, '0');
+const pad = (num: number): string => String(num).padStart(2, '0');
 
 export const parseTime = (date: Date): string => {
   const hours = pad(date.getHours());

--- a/test/unit/args.test.ts
+++ b/test/unit/args.test.ts
@@ -1,69 +1,34 @@
 import { describe } from '../../src/modules/helpers/describe.js';
 import { it } from '../../src/modules/helpers/it/core.js';
 import { assert } from '../../src/modules/essentials/assert.js';
-import {
-  getArg,
-  hasArg,
-  argToArray,
-  getPaths,
-} from '../../src/parsers/get-arg.js';
+import { test } from '../../src/parsers/get-arg.js';
+
+const { parseArgs } = test;
 
 describe('CLI Argument Handling Functions', () => {
   it('should get argument value', () => {
-    const args = ['--arg=value'];
-    const result = getArg('arg', '--', args);
-    assert.strictEqual(result, 'value', 'Argument value should be "value"');
-  });
-
-  it('should return undefined for missing argument value', () => {
-    const args = ['--arg'];
-    const result = getArg('arg', '--', args);
-    assert.strictEqual(result, undefined, 'Argument value should be undefined');
+    const args = ['--envfile=value'];
+    const result = parseArgs(args);
+    assert.strictEqual(result.values.envfile, 'value', 'Argument value should be "value"');
   });
 
   it('should check if argument exists', () => {
-    const args = ['--checkArg'];
-    const result = hasArg('checkArg', '--', args);
-    assert.strictEqual(result, true, 'Argument should exist');
+    const args = ['--watch'];
+    const result = parseArgs(args);
+    assert.strictEqual(result.values.watch, true, 'Argument should exist');
   });
 
   it('should check if argument does not exist', () => {
-    const args = ['--anotherArg'];
-    const result = hasArg('checkArg', '--', args);
-    assert.strictEqual(result, false, 'Argument should not exist');
-  });
-
-  it('should convert argument to array', () => {
-    const args = ['--array=1,2,3'];
-    const result = argToArray('array', '--', args);
-    assert.deepStrictEqual(
-      result,
-      ['1', '2', '3'],
-      'Argument should be converted to array [1, 2, 3]'
-    );
-  });
-
-  it('should return empty array for argument without value', () => {
-    const args = ['--array'];
-    const result = argToArray('array', '--', args);
-    assert.deepStrictEqual(
-      result,
-      [],
-      'Argument should be converted to an empty array'
-    );
-  });
-
-  it('should return undefined for non-existing argument to array', () => {
-    const args: string[] = [];
-    const result = argToArray('array', '--', args);
-    assert.strictEqual(result, undefined, 'Argument should be undefined');
+    const args = ['--watch'];
+    const result = parseArgs(args);
+    assert.strictEqual(result.values.debug, undefined, 'Argument should not exist');
   });
 
   it('should return paths without prefix arguments', () => {
     const args = ['--arg=value', 'path1', 'path2'];
-    const result = getPaths('--', args);
+    const result = parseArgs(args);
     assert.deepStrictEqual(
-      result,
+      result.positionals,
       ['path1', 'path2'],
       'Should return ["path1", "path2"]'
     );
@@ -71,9 +36,9 @@ describe('CLI Argument Handling Functions', () => {
 
   it('should split paths by comma', () => {
     const args = ['path1,path2,path3'];
-    const result = getPaths('--', args);
+    const result = parseArgs(args);
     assert.deepStrictEqual(
-      result,
+      result.positionals,
       ['path1', 'path2', 'path3'],
       'Should split paths by comma'
     );
@@ -81,19 +46,19 @@ describe('CLI Argument Handling Functions', () => {
 
   it('should return undefined if no paths provided', () => {
     const args = ['--arg=value'];
-    const result = getPaths('--', args);
-    assert.strictEqual(
-      result,
-      undefined,
+    const result = parseArgs(args);
+    assert.deepStrictEqual(
+      result.positionals,
+      [],
       'Should return undefined if no paths'
     );
   });
 
   it('should handle mixed arguments with and without prefix', () => {
     const args = ['--arg=value', 'path1', '--another=value', 'path2,path3'];
-    const result = getPaths('--', args);
+    const result = parseArgs(args);
     assert.deepStrictEqual(
-      result,
+      result.positionals,
       ['path1', 'path2', 'path3'],
       'Should return ["path1", "path2", "path3"]'
     );
@@ -101,10 +66,10 @@ describe('CLI Argument Handling Functions', () => {
 
   it('should handle empty array', () => {
     const args: string[] = [];
-    const result = getPaths('--', args);
-    assert.strictEqual(
-      result,
-      undefined,
+    const result = parseArgs(args);
+    assert.deepStrictEqual(
+      result.positionals,
+      [],
       'Should return undefined for empty array'
     );
   });

--- a/test/unit/env-services.test.ts
+++ b/test/unit/env-services.test.ts
@@ -89,10 +89,12 @@ describe('resolveEnvVariables', () => {
   it('should resolve environment variables', () => {
     const env = { MY_VAR: 'resolvedValue' };
     assert.strictEqual(
+      // biome-ignore lint/nursery/noTemplateCurlyInString:
       resolveEnvVariables('value is ${MY_VAR}', env),
       'value is resolvedValue'
     );
     assert.strictEqual(
+      // biome-ignore lint/nursery/noTemplateCurlyInString:
       resolveEnvVariables('${MY_VAR} is set', env),
       'resolvedValue is set'
     );
@@ -101,10 +103,12 @@ describe('resolveEnvVariables', () => {
   it('should handle missing environment variables', () => {
     const env = { MY_VAR: 'resolvedValue' };
     assert.strictEqual(
+      // biome-ignore lint/nursery/noTemplateCurlyInString:
       resolveEnvVariables('value is ${UNKNOWN_VAR}', env),
       'value is '
     );
     assert.strictEqual(
+      // biome-ignore lint/nursery/noTemplateCurlyInString:
       resolveEnvVariables('${UNKNOWN_VAR} is set', env),
       ' is set'
     );

--- a/test/unit/watch.test.ts
+++ b/test/unit/watch.test.ts
@@ -18,7 +18,7 @@ const runtime = getRuntime();
 const tmpDir = path.resolve('.', 'test/__fixtures__/.temp/watch');
 const humanDelay = 750;
 
-const createTempDir = () => {
+const createTempDir = (): void => {
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir, { recursive: true });
   }


### PR DESCRIPTION
use [parseArgs](https://nodejs.org/api/util.html#utilparseargsconfig) from `node:util`

- more compact
- more native
- more standardized