### PR TITLE
ci: temp disable benchmarks comment

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -53,29 +53,29 @@ jobs:
       - name: 🎖️ Rock it
         run: npm run benchmark
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Benchmark Results
+      # - name: Find Comment
+      #   uses: peter-evans/find-comment@v3
+      #   id: fc
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     comment-author: 'github-actions[bot]'
+      #     body-includes: Benchmark Results
 
-      - name: 🤖 Actions - Creating Comment
-        if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: './benchmark/output.md'
+      # - name: 🤖 Actions - Creating Comment
+      #   if: steps.fc.outputs.comment-id == ''
+      #   uses: peter-evans/create-or-update-comment@v4
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     body-path: './benchmark/output.md'
 
-      - name: 🤖 Actions - Updating Comment
-        if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body-path: './benchmark/output.md'
+      # - name: 🤖 Actions - Updating Comment
+      #   if: steps.fc.outputs.comment-id != ''
+      #   uses: peter-evans/create-or-update-comment@v4
+      #   with:
+      #     comment-id: ${{ steps.fc.outputs.comment-id }}
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     edit-mode: replace
+      #     body-path: './benchmark/output.md'
 
       - name: 🐷 Ensure Poku
         run: |


### PR DESCRIPTION
I need to understand why when an external contributor submits a _PR_, **GitHub** denies access to the comment.

- The benchmark _CI_ remain normally.