### PR TITLE
chore!: remove `allow-hrtime` by default for Deno

### DIFF
--- a/src/parsers/get-runner.ts
+++ b/src/parsers/get-runner.ts
@@ -16,13 +16,7 @@ export const runner = (filename: string, configs?: Configs): string[] => {
       ? configs.deno.allow
           .map((allow) => (allow ? `--allow-${allow}` : ''))
           .filter((allow) => allow)
-      : [
-          '--allow-read',
-          '--allow-env',
-          '--allow-run',
-          '--allow-net',
-          '--allow-hrtime',
-        ];
+      : ['--allow-read', '--allow-env', '--allow-run', '--allow-net'];
 
     const denoDeny = configs?.deno?.deny
       ? configs.deno.deny

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -3,6 +3,6 @@ import { poku } from '../src/modules/essentials/poku.js';
 poku(['test/unit', 'test/integration', 'test/e2e'], {
   debug: true,
   deno: {
-    allow: ['read', 'write', 'hrtime', 'env', 'run', 'net'],
+    allow: ['read', 'write', 'env', 'run', 'net'],
   },
 });

--- a/test/unit/deno/allow.test.ts
+++ b/test/unit/deno/allow.test.ts
@@ -14,7 +14,6 @@ test('Deno Permissions (Allow)', () => {
       '--allow-env',
       '--allow-run',
       '--allow-net',
-      '--allow-hrtime',
     ],
     'Default Permissions'
   );

--- a/website/docs/documentation/poku/config-files.mdx
+++ b/website/docs/documentation/poku/config-files.mdx
@@ -74,7 +74,7 @@ module.exports = defineConfig({
   },
   platform: 'node', // "node", "bun" and "deno"
   deno: {
-    allow: ['run', 'env', 'read', 'hrtime', 'net'],
+    allow: ['run', 'env', 'read', 'net'],
     deny: [], // Same as allow
     cjs: ['.js', '.cjs'], // specific extensions
     // "cjs": true // all extensions
@@ -126,7 +126,7 @@ Create a `.pokurc.json` (or `.pokurc.jsonc`) in your project's root directory, f
   },
   "platform": "node", // "node", "bun" and "deno"
   "deno": {
-    "allow": ["run", "env", "read", "hrtime", "net"],
+    "allow": ["run", "env", "read", "net"],
     "deny": [], // Same as allow
     "cjs": [".js", ".cjs"], // specific extensions
     // "cjs": true // all extensions

--- a/website/docs/documentation/poku/options/deno.mdx
+++ b/website/docs/documentation/poku/options/deno.mdx
@@ -10,7 +10,7 @@ Exclusive options for **Deno** platform.
 
 Change permissions for **Deno**.
 
-By default **Poku** uses `--allow-run`, `--allow-env`, `--allow-read`, `allow-hrtime` and `--allow-net`.
+By default **Poku** uses `--allow-run`, `--allow-env`, `--allow-read` and `--allow-net`.
 
 ### CLI
 

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/config-files.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/config-files.mdx
@@ -76,7 +76,7 @@ module.exports = defineConfig({
   },
   platform: 'node', // "node", "bun" e "deno"
   deno: {
-    allow: ['run', 'env', 'read', 'hrtime', 'net'],
+    allow: ['run', 'env', 'read', 'net'],
     deny: [], // O mesmo que allow
     cjs: ['.js', '.cjs'], // extensões específicas
     // "cjs": true // todas as extensões
@@ -128,7 +128,7 @@ Crie um arquivo `.pokurc.json` (ou `.pokurc.jsonc`) no diretório raiz do seu pr
   },
   "platform": "node", // "node", "bun" e "deno"
   "deno": {
-    "allow": ["run", "env", "read", "hrtime", "net"],
+    "allow": ["run", "env", "read", "net"],
     "deny": [], // O mesmo que allow
     "cjs": [".js", ".cjs"], // extensões específicas
     // "cjs": true // todas as extensões

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/options/deno.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/options/deno.mdx
@@ -10,7 +10,7 @@ Opções exclusivas para a plataforma **Deno**.
 
 Altere as permissões para o **Deno**.
 
-Por padrão, o **Poku** utiliza `--allow-run`, `--allow-env`, `--allow-read`, `allow-hrtime` e `--allow-net`.
+Por padrão, o **Poku** utiliza `--allow-run`, `--allow-env`, `--allow-read` e `--allow-net`.
 
 ### CLI
 


### PR DESCRIPTION
Since **Deno** `v2`, the `allow-hrtime` was removed:

> <img width="849" alt="Deno v2 Warning" src="https://github.com/user-attachments/assets/3192ce38-0aca-4acd-abfc-d6dc5a732cd2">

---

For **Deno** `v1`, you can use it normally by using:

```sh
npx poku --denoAllow='hrtime,...'
```