### PR TITLE
docs: Deno `v2` doesn't need `commonjs` polyfills

### DIFF
--- a/test/unit/watch.test.ts
+++ b/test/unit/watch.test.ts
@@ -10,11 +10,12 @@ import { sleep } from '../../src/modules/helpers/wait-for.js';
 import { skip } from '../../src/modules/helpers/skip.js';
 import type { WatchCallback } from '../../src/@types/watch.js';
 
-if (nodeVersion && nodeVersion < 16) {
+const runtime = getRuntime();
+
+if (runtime === 'deno' || (nodeVersion && nodeVersion < 16)) {
   skip('rmSync is available from Node.js 16 onwards');
 }
 
-const runtime = getRuntime();
 const tmpDir = path.resolve('.', 'test/__fixtures__/.temp/watch');
 const humanDelay = 750;
 

--- a/website/docs/documentation/poku/options/deno.mdx
+++ b/website/docs/documentation/poku/options/deno.mdx
@@ -98,6 +98,14 @@ poku('./test', {
 >
 > `cjs: boolean | string[]`
 
+:::danger Important
+
+From **Deno** `v2`, simply set the type to `commonjs` in your **package.json** or use the `.cjs` extension.
+
+For **Deno** `v1`, you can follow the instructions bellow.
+
+:::
+
 Now, it's possible to run tests that use `require`, `module.exports` and `module` directly with **Deno** 🎉
 
 It's a great feature to test if a project created primarily in **Node.js** or **Bun** is also compatible with **Deno** without the need to transpile the code or use workarounds.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/options/deno.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/documentation/poku/options/deno.mdx
@@ -98,6 +98,14 @@ poku('./test', {
 >
 > `cjs: boolean | string[]`
 
+:::danger Important
+
+From **Deno** `v2`, simply set the type to `commonjs` in your **package.json** or use the `.cjs` extension.
+
+For **Deno** `v1`, you can follow the instructions bellow.
+
+:::
+
 Agora é possível executar testes que utilizam `require`, `module.exports` e `module` diretamente com o **Deno** 🎉
 
 É uma ótima funcionalidade para testar se um projeto criado, principalmente em **Node.js** ou **Bun**, também é compatível com o **Deno** sem a necessidade de transpilar o código ou usar gambiarras.


### PR DESCRIPTION
Closes #855.