### PR TITLE
feat(cli): stable enforce values validation

### DIFF
--- a/src/bin/help.ts
+++ b/src/bin/help.ts
@@ -34,8 +34,7 @@ const summary: [string, string][] = [
   ['--watchInterval', 'Set an interval for watch events.'],
 ];
 const sortedSummary = summary.sort(([a], [b]) => a.localeCompare(b));
-const largeEndPad = (() =>
-  Math.max(...summary.map(([start]) => start.length)))();
+const largeEndPad = Math.max(...summary.map(([start]) => start.length));
 
 const header = `
 🐷 ${format(' Poku — CLI Usage ').bg('brightMagenta')}

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -99,7 +99,7 @@ import { getConfigs } from '../parsers/options.js';
   }
 
   if (enforce) {
-    const { checkFlags } = require('./enforce.js');
+    const { checkFlags } = require('../services/enforce.js');
 
     checkFlags();
   }

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -8,21 +8,16 @@ import { envFile } from '../modules/helpers/env.js';
 import { poku } from '../modules/essentials/poku.js';
 import { log, hr } from '../services/write.js';
 import { getConfigs } from '../parsers/options.js';
-import { GLOBAL } from '../configs/poku.js';
+import { GLOBAL, VERSION } from '../configs/poku.js';
 
 (async () => {
   if (hasArg('version') || hasArg('v', '-')) {
-    const { VERSION } = require('../configs/poku.js');
-
     log(VERSION);
     return;
   }
 
   if (hasArg('help') || hasArg('h', '-')) {
-    const { help } = require('./help.js');
-
-    help();
-
+    require('./help.js').help();
     return;
   }
 
@@ -126,11 +121,7 @@ import { GLOBAL } from '../configs/poku.js';
     GLOBAL.envFile = getArg('envFile') ?? defaultConfigs?.envFile ?? '.env';
   }
 
-  if (enforce) {
-    const { enforce: ensure } = require('../services/enforce.js');
-
-    await ensure();
-  }
+  if (enforce) require('../services/enforce.js').enforce();
 
   /* c8 ignore start */ // Process-based
   if (killPort || defaultConfigs?.kill?.port) {
@@ -176,9 +167,5 @@ import { GLOBAL } from '../configs/poku.js';
   await Promise.all(tasks);
   await poku(dirs, GLOBAL.options);
 
-  if (watchMode) {
-    const { startWatch } = require('./watch.js');
-
-    await startWatch(dirs, GLOBAL.options);
-  }
+  if (watchMode) await require('./watch.js').startWatch(dirs, GLOBAL.options);
 })();

--- a/src/configs/files.ts
+++ b/src/configs/files.ts
@@ -1,11 +1,11 @@
 import type { FileResults } from '../@types/list-files.js';
 import type { FinalResults, States } from '../@types/poku.js';
 
-export const states = {} as States;
+export const states = Object.create(null) as States;
 
 export const fileResults: FileResults = {
   success: new Map(),
   fail: new Map(),
 };
 
-export const finalResults = {} as FinalResults;
+export const finalResults = Object.create(null) as FinalResults;

--- a/src/configs/poku.ts
+++ b/src/configs/poku.ts
@@ -1,4 +1,5 @@
 import { env, cwd } from 'node:process';
+import type { Configs } from '../@types/poku.js';
 
 export const results = {
   success: 0,
@@ -16,4 +17,7 @@ export const GLOBAL = {
   runAsOnly: false,
   isPoku: typeof env?.POKU_FILE === 'string' && env?.POKU_FILE.length > 0,
   FILE: env.POKU_FILE,
+  options: {} as Configs,
+  configFile: undefined as string | undefined,
+  envFile: undefined as string | undefined,
 };

--- a/src/configs/poku.ts
+++ b/src/configs/poku.ts
@@ -17,7 +17,7 @@ export const GLOBAL = {
   runAsOnly: false,
   isPoku: typeof env?.POKU_FILE === 'string' && env?.POKU_FILE.length > 0,
   FILE: env.POKU_FILE,
-  options: {} as Configs,
+  options: Object.create(null) as Configs,
   configFile: undefined as string | undefined,
   envFile: undefined as string | undefined,
 };

--- a/src/modules/helpers/describe.ts
+++ b/src/modules/helpers/describe.ts
@@ -29,7 +29,8 @@ export async function describeBase(
   if (title) {
     indentation.hasDescribe = true;
 
-    const { background, icon } = options ?? {};
+    const { background, icon } =
+      options ?? (Object.create(null) as DescribeOptions);
     const message = `${cb ? format('◌').dim() : (icon ?? '☰')} ${cb ? format(title).dim() : format(title).bold()}`;
     const noBackground = !background;
 

--- a/src/parsers/options.ts
+++ b/src/parsers/options.ts
@@ -29,5 +29,5 @@ export const getConfigs = async (
     } catch {}
   }
 
-  return {};
+  return Object.create(null);
 };

--- a/src/services/enforce.ts
+++ b/src/services/enforce.ts
@@ -1,8 +1,44 @@
 import { argv, exit } from 'node:process';
+import { stat } from 'node:fs/promises';
 import { log, hr } from './write.js';
 import { format } from './format.js';
+import { GLOBAL } from '../configs/poku.js';
+import { getArg, hasArg } from '../parsers/get-arg.js';
 
-export const checkFlags = () => {
+const unrecognizedFlags: string[] = [];
+const unrecognizedValues: string[] = [];
+
+const printErrors = (type: 'flags' | 'values', errorList: string[]) => {
+  log(
+    `${format(`Unrecognized ${type}:`).bold()}\n\n${errorList.map((flag) => format(flag).fail()).join('\n')}`
+  );
+};
+
+const pathExists = async (arg: string, path: string): Promise<void> => {
+  try {
+    await stat(path);
+  } catch {
+    unrecognizedValues.push(`--${arg}: ./${path} doesn't exists.`);
+  }
+};
+
+const checkUselessValue = (arg: string): void => {
+  const prefix = arg.length === 1 ? '-' : '--';
+
+  if (typeof getArg(arg, prefix) !== 'undefined')
+    unrecognizedValues.push(
+      `${prefix}${arg}: this flag shouldn't receive a value.`
+    );
+};
+
+const checkRequiredValue = (arg: string): void => {
+  const prefix = arg.length === 1 ? '-' : '--';
+
+  if (hasArg(arg, prefix) && typeof getArg(arg, prefix) === 'undefined')
+    unrecognizedValues.push(`${prefix}${arg}: this flag require a value.`);
+};
+
+const checkFlags = () => {
   const allowedFlags = new Set([
     '--concurrency',
     '--config',
@@ -31,7 +67,6 @@ export const checkFlags = () => {
   ]);
 
   const args = argv.slice(2);
-  const unrecognizedFlags: string[] = [];
 
   for (const arg of args) {
     const flagName = arg.split('=')[0];
@@ -39,13 +74,62 @@ export const checkFlags = () => {
     if (!allowedFlags.has(flagName) && flagName.startsWith('-'))
       unrecognizedFlags.push(flagName);
   }
+};
+
+const checkValues = async () => {
+  for (const flag of [
+    'debug',
+    'enforce',
+    'failFast',
+    'only',
+    'quiet',
+    'sequential',
+    'watch',
+    'd',
+    'x',
+    'q',
+    'w',
+  ])
+    checkUselessValue(flag);
+
+  for (const flag of [
+    'concurrency',
+    'config',
+    'killPid',
+    'killPort',
+    'watchInterval',
+    'c',
+  ])
+    checkRequiredValue(flag);
+
+  if (GLOBAL.configFile) await pathExists('config', GLOBAL.configFile);
+
+  if (GLOBAL.envFile) await pathExists('envFile', GLOBAL.envFile);
+  else if (hasArg('envFile') && !getArg('envFile'))
+    await pathExists('envFile', '.env');
+
+  if (
+    getArg('concurrency') &&
+    typeof GLOBAL.options.concurrency === 'undefined'
+  )
+    unrecognizedValues.push('--concurrency: expects for a valid integer.');
+};
+
+export const enforce = async () => {
+  checkFlags();
+  await checkValues();
 
   if (unrecognizedFlags.length > 0) {
     hr();
-    log(
-      `${format('Unrecognized flags:').bold()}\n\n${unrecognizedFlags.map((flag) => format(flag).fail()).join('\n')}`
-    );
-    hr();
-    exit(1);
+    printErrors('flags', unrecognizedFlags);
+    if (unrecognizedValues.length === 0) hr();
   }
+
+  if (unrecognizedValues.length > 0) {
+    hr();
+    printErrors('values', unrecognizedValues);
+    hr();
+  }
+
+  if (unrecognizedFlags.length > 0 || unrecognizedValues.length > 0) exit(1);
 };

--- a/src/services/enforce.ts
+++ b/src/services/enforce.ts
@@ -1,6 +1,6 @@
 import { argv, exit } from 'node:process';
-import { log, hr } from '../services/write.js';
-import { format } from '../services/format.js';
+import { log, hr } from './write.js';
+import { format } from './format.js';
 
 export const checkFlags = () => {
   const allowedFlags = new Set([

--- a/test/e2e/cli-ensure-flags.test.ts
+++ b/test/e2e/cli-ensure-flags.test.ts
@@ -13,25 +13,91 @@ if (isBuild || runtime === 'deno') {
 
 describe('Enforce Option', async () => {
   await it('--enforce', async () => {
-    const output = await inspectPoku('--enforce -D --paralell', {
-      cwd: 'test/__fixtures__/e2e/no-tests',
-    });
+    const output = await inspectPoku(
+      '--enforce -D --paralell --concurrency=g --config=test.json --envFile --debug=test --watchInterval',
+      {
+        cwd: 'test/__fixtures__/e2e/no-tests',
+      }
+    );
 
     assert.strictEqual(output.exitCode, 1, 'Exit Code needs to be 1');
-    assert(/Unrecognized flags/.test(output.stdout), 'Has unrecognized flags');
-    assert(/-D/.test(output.stdout), 'Short flag: wrong case for valid option');
-    assert(/--paralell/.test(output.stdout), 'Invalid option');
+    assert(/Ensure Enabled/.test(output.stdout), '"ensure" is enabled');
+    assert(
+      /-D: unrecognized flag./.test(output.stdout),
+      'Has unrecognized short flags'
+    );
+    assert(
+      /--paralell: unrecognized flag./.test(output.stdout),
+      'Has unrecognized flags'
+    );
+    assert(
+      /--debug: this flag shouldn't receive a value./.test(output.stdout),
+      'Has unrecognized values in non-value flags'
+    );
+    assert(
+      /--config: .\/test.json doesn't exists./.test(output.stdout),
+      "Config file doesn't exists"
+    );
+    assert(
+      /--envFile: .\/.env doesn't exists./.test(output.stdout),
+      "Default .env file doesn't exists"
+    );
+    assert(
+      /--envFile: .\/.env doesn't exists./.test(output.stdout),
+      "Env file doesn't exists"
+    );
+    assert(
+      /--watchInterval: this flag require a value./.test(output.stdout),
+      'Missing required value'
+    );
+    assert(
+      /--concurrency: expects for a valid integer./.test(output.stdout),
+      'Wrong value'
+    );
   });
 
   await it('-x', async () => {
-    const output = await inspectPoku('-x -D --paralell', {
-      cwd: 'test/__fixtures__/e2e/no-tests',
-    });
+    const output = await inspectPoku(
+      '-x -D --paralell --concurrency=g --config=test.json --envFile --debug=test --watchInterval',
+      {
+        cwd: 'test/__fixtures__/e2e/no-tests',
+      }
+    );
 
     assert.strictEqual(output.exitCode, 1, 'Exit Code needs to be 1');
-    assert(/Unrecognized flags/.test(output.stdout), 'Has unrecognized flags');
-    assert(/-D/.test(output.stdout), 'Short flag: wrong case for valid option');
-    assert(/--paralell/.test(output.stdout), 'Invalid option');
+    assert(/Ensure Enabled/.test(output.stdout), '"ensure" is enabled');
+    assert(
+      /-D: unrecognized flag./.test(output.stdout),
+      'Has unrecognized short flags'
+    );
+    assert(
+      /--paralell: unrecognized flag./.test(output.stdout),
+      'Has unrecognized flags'
+    );
+    assert(
+      /--debug: this flag shouldn't receive a value./.test(output.stdout),
+      'Has unrecognized values in non-value flags'
+    );
+    assert(
+      /--config: .\/test.json doesn't exists./.test(output.stdout),
+      "Config file doesn't exists"
+    );
+    assert(
+      /--envFile: .\/.env doesn't exists./.test(output.stdout),
+      "Default .env file doesn't exists"
+    );
+    assert(
+      /--envFile: .\/.env doesn't exists./.test(output.stdout),
+      "Env file doesn't exists"
+    );
+    assert(
+      /--watchInterval: this flag require a value./.test(output.stdout),
+      'Missing required value'
+    );
+    assert(
+      /--concurrency: expects for a valid integer./.test(output.stdout),
+      'Wrong value'
+    );
   });
 
   await it('No ensure', async () => {
@@ -41,7 +107,7 @@ describe('Enforce Option', async () => {
 
     assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
     assert(
-      !/Unrecognized flags/.test(output.stdout),
+      !/Ensure Enabled/.test(output.stdout),
       "Doesn't recognized wrong flags"
     );
   });


### PR DESCRIPTION
Now, `--ensure` or `-x` flags check for:

- [x] Invalid flags.
- [x] Flags with required values, but with no value.
- [x] Invalid values (`--config`, `--envFile`, `--concurrency`).
- [x] Flags that don't use values, but have some values in them.

**Next step:**

- Also check the configuration files.

---

Related:

- #703
- #801