### PR TITLE
fix: ensure sequential runs respect the previous test's end

### DIFF
--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -70,7 +70,8 @@ export const runTests = async (dir: string): Promise<boolean> => {
     await runNext();
   };
 
-  for (let i = 0; i < concurrency; i++) runNext();
+  for (let i = 0; i < concurrency; i++)
+    concurrency === 1 ? await runNext() : runNext();
 
   return await done;
 };

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -28,6 +28,7 @@ export const runTests = async (dir: string): Promise<boolean> => {
       configs.concurrency ?? Math.max(availableParallelism() - 1, 1);
     return limit <= 0 ? files.length || 1 : limit;
   })();
+  const isSequential = concurrency === 1;
 
   const done = new Promise<boolean>((resolve) => {
     resolveDone = resolve;
@@ -67,11 +68,11 @@ export const runTests = async (dir: string): Promise<boolean> => {
 
     activeTests--;
 
-    concurrency === 1 ? await runNext() : runNext();
+    isSequential ? await runNext() : runNext();
   };
 
   for (let i = 0; i < concurrency; i++)
-    concurrency === 1 ? await runNext() : runNext();
+    isSequential ? await runNext() : runNext();
 
   return await done;
 };

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -67,7 +67,7 @@ export const runTests = async (dir: string): Promise<boolean> => {
 
     activeTests--;
 
-    await runNext();
+    concurrency === 1 ? await runNext() : runNext();
   };
 
   for (let i = 0; i < concurrency; i++)

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -16,7 +16,6 @@ export const runTests = async (dir: string): Promise<boolean> => {
   let allPassed = true;
   let activeTests = 0;
   let resolveDone: (value: boolean) => void;
-  let rejectDone: (reason?: Error) => void;
 
   const { configs } = GLOBAL;
   const testDir = join(cwd, dir);
@@ -32,7 +31,6 @@ export const runTests = async (dir: string): Promise<boolean> => {
 
   const done = new Promise<boolean>((resolve, reject) => {
     resolveDone = resolve;
-    rejectDone = reject;
   });
 
   const runNext = async () => {
@@ -46,32 +44,30 @@ export const runTests = async (dir: string): Promise<boolean> => {
 
     activeTests++;
 
-    try {
-      const testPassed = await runTestFile(filePath);
+    const testPassed = await runTestFile(filePath);
 
-      if (testPassed) ++results.passed;
-      else {
-        ++results.failed;
-        allPassed = false;
+    if (testPassed) ++results.passed;
+    else {
+      ++results.failed;
+      allPassed = false;
 
-        if (configs.failFast) {
-          if (showLogs) {
-            hr();
-            console.error(failFastError);
-            log(
-              `\n    ${format('File:').bold()} ${format(`./${relative(cwd, filePath)}`).fail()}`
-            );
-            hr();
-          }
-
-          process.exit(1);
+      if (configs.failFast) {
+        if (showLogs) {
+          hr();
+          console.error(failFastError);
+          log(
+            `\n    ${format('File:').bold()} ${format(`./${relative(cwd, filePath)}`).fail()}`
+          );
+          hr();
         }
+
+        process.exit(1);
       }
-    } finally {
-      activeTests--;
     }
 
-    runNext().catch(rejectDone);
+    activeTests--;
+
+    await runNext();
   };
 
   for (let i = 0; i < concurrency; i++) runNext();

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -29,7 +29,7 @@ export const runTests = async (dir: string): Promise<boolean> => {
     return limit <= 0 ? files.length || 1 : limit;
   })();
 
-  const done = new Promise<boolean>((resolve, reject) => {
+  const done = new Promise<boolean>((resolve) => {
     resolveDone = resolve;
   });
 

--- a/test/__fixtures__/e2e/concurrency/sequence/a/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/a/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/a/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/a/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/a/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/a/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/b/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/b/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/b/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/b/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/b/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/b/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/c/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/c/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/c/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/c/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/c/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/c/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/d/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/d/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/d/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/d/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/d/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/d/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/e/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/e/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/e/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/e/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/e/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/e/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/f/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/f/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/f/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/f/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/f/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/f/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/g/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/g/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/g/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/g/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/g/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/g/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/h/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/h/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/h/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/h/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/h/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/h/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/i/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/i/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/i/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/i/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/i/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/i/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/j/a.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/j/a.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/j/b.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/j/b.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/j/c.test.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/j/c.test.ts
@@ -1,0 +1,6 @@
+import { test } from '../../../../../../src/modules/helpers/test.js';
+import { server } from '../server.js';
+
+test(async () => {
+  await server();
+});

--- a/test/__fixtures__/e2e/concurrency/sequence/server.ts
+++ b/test/__fixtures__/e2e/concurrency/sequence/server.ts
@@ -1,0 +1,8 @@
+import http from 'node:http';
+
+export const server = async () => {
+  const server = http.createServer();
+
+  await new Promise<void>((resolve) => server.listen(8000, resolve));
+  await new Promise((resolve) => server.close(resolve));
+};

--- a/test/e2e/concurrency.test.ts
+++ b/test/e2e/concurrency.test.ts
@@ -1,0 +1,19 @@
+import { inspectPoku, isBuild } from '../__utils__/capture-cli.test.js';
+import { assert } from '../../src/modules/essentials/assert.js';
+import { skip } from '../../src/modules/helpers/skip.js';
+import { test } from '../../src/modules/helpers/test.js';
+
+if (isBuild) skip();
+
+test('Start 30 servers on the same port', async () => {
+  const results = await inspectPoku('--killPort=8000 -d --sequential', {
+    cwd: 'test/__fixtures__/e2e/concurrency/sequence',
+  });
+
+  if (results.exitCode !== 0) {
+    console.log(results.stdout);
+    console.log(results.stderr);
+  }
+
+  assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
+});


### PR DESCRIPTION
When using `--sequential`, in some cases there may be a delay between the conclusion of a test and the start of the next. This _PR_ fixes it.
