### PR TITLE
refactor: remove unnecessary `await`

### DIFF
--- a/src/modules/helpers/create-service.ts
+++ b/src/modules/helpers/create-service.ts
@@ -144,7 +144,7 @@ const backgroundProcess = (
   });
 
 /** Starts a file in a background process (useful for servers, APIs, etc.) */
-export const startService = async (
+export const startService = (
   file: string,
   options?: StartServiceOptions
 ): Promise<{ end: End }> => {
@@ -168,7 +168,7 @@ export const startService = async (
  *
  * By default it uses **npm**, but you can costumize it using the `runner` option.
  */
-export const startScript = async (
+export const startScript = (
   script: string,
   options?: StartScriptOptions
 ): Promise<{ end: End }> => {

--- a/src/modules/helpers/create-service.ts
+++ b/src/modules/helpers/create-service.ts
@@ -152,7 +152,7 @@ export const startService = async (
   const runtime = runtimeOptions.shift()!;
   const runtimeArgs = [...runtimeOptions, file];
 
-  return await backgroundProcess(
+  return backgroundProcess(
     runtime,
     runtimeArgs,
     normalize(sanitizePath(file)),
@@ -177,7 +177,7 @@ export const startScript = async (
   const runtime = runtimeOptions.shift()!;
   const runtimeArgs = [...runtimeOptions, script];
 
-  return await backgroundProcess(runtime, runtimeArgs, script, {
+  return backgroundProcess(runtime, runtimeArgs, script, {
     ...options,
     runner,
   });

--- a/src/modules/helpers/get-pids.ts
+++ b/src/modules/helpers/get-pids.ts
@@ -22,7 +22,7 @@ const getPIDsByPorts = async (port: number | number[]): Promise<number[]> => {
   return PIDs;
 };
 
-const getPIDsByRange = async (
+const getPIDsByRange = (
   startsAt: number,
   endsAt: number
 ): Promise<number[]> => {

--- a/src/modules/helpers/get-pids.ts
+++ b/src/modules/helpers/get-pids.ts
@@ -28,7 +28,7 @@ const getPIDsByRange = async (
 ): Promise<number[]> => {
   const ports = populateRange(startsAt, endsAt);
 
-  return await getPIDs(ports);
+  return getPIDs(ports);
 };
 
 /** Returns an array containing the ID of all processes listening to the specified port */

--- a/src/modules/helpers/list-files.ts
+++ b/src/modules/helpers/list-files.ts
@@ -48,7 +48,7 @@ export const getAllFiles = async (
         return [sanitizePath(dirPath)];
       }
 
-      return await readdir(sanitizePath(dirPath));
+      return readdir(sanitizePath(dirPath));
     } catch (error) {
       console.error(error);
       process.exit(1);

--- a/src/services/container.ts
+++ b/src/services/container.ts
@@ -97,7 +97,7 @@ export class DockerContainer {
 
     if (this.envFile) args.push(...['--env-file', this.envFile]);
 
-    return await runDockerCommand(
+    return runDockerCommand(
       'docker',
       [...args, this.tagName],
       { cwd: this.cwd },
@@ -106,7 +106,7 @@ export class DockerContainer {
   }
 
   async stop() {
-    return await runDockerCommand(
+    return runDockerCommand(
       'docker',
       ['stop', this.containerName],
       { cwd: this.cwd },
@@ -174,12 +174,7 @@ export class DockerCompose {
     if (this.build) args.push('--build');
     if (this.serviceName) args.push(this.serviceName);
 
-    return await runDockerCommand(
-      'docker',
-      args,
-      { cwd: this.cwd },
-      this.verbose
-    );
+    return runDockerCommand('docker', args, { cwd: this.cwd }, this.verbose);
   }
 
   async down() {
@@ -188,7 +183,7 @@ export class DockerCompose {
     if (this.envFile) args.push(...['--env-file', this.envFile]);
     if (this.projectName) args.push(...['-p', this.projectName]);
 
-    return await runDockerCommand(
+    return runDockerCommand(
       'docker',
       ['compose', ...args, 'down'],
       { cwd: this.cwd },

--- a/src/services/container.ts
+++ b/src/services/container.ts
@@ -85,7 +85,7 @@ export class DockerContainer {
     );
   }
 
-  async start() {
+  start() {
     const args: string[] = ['run'];
 
     args.push(this.detach !== false ? '-d' : '--init');
@@ -105,7 +105,7 @@ export class DockerContainer {
     );
   }
 
-  async stop() {
+  stop() {
     return runDockerCommand(
       'docker',
       ['stop', this.containerName],
@@ -162,7 +162,7 @@ export class DockerCompose {
     this.verbose = verbose;
   }
 
-  async up() {
+  up() {
     const args: string[] = ['compose', '-f', this.file];
 
     if (this.envFile) args.push(...['--env-file', this.envFile]);
@@ -177,7 +177,7 @@ export class DockerCompose {
     return runDockerCommand('docker', args, { cwd: this.cwd }, this.verbose);
   }
 
-  async down() {
+  down() {
     const args: string[] = ['-f', this.file];
 
     if (this.envFile) args.push(...['--env-file', this.envFile]);

--- a/src/services/each.ts
+++ b/src/services/each.ts
@@ -48,13 +48,13 @@ const eachCore = async (
   }
 };
 
-export const beforeEach = async (fileRelative: string) => {
+export const beforeEach = (fileRelative: string) => {
   if (GLOBAL.configs.beforeEach) return eachCore('beforeEach', fileRelative);
 
   return true;
 };
 
-export const afterEach = async (fileRelative: string) => {
+export const afterEach = (fileRelative: string) => {
   if (GLOBAL.configs.afterEach) return eachCore('afterEach', fileRelative);
 
   return true;

--- a/src/services/each.ts
+++ b/src/services/each.ts
@@ -49,15 +49,13 @@ const eachCore = async (
 };
 
 export const beforeEach = async (fileRelative: string) => {
-  if (GLOBAL.configs.beforeEach)
-    return await eachCore('beforeEach', fileRelative);
+  if (GLOBAL.configs.beforeEach) return eachCore('beforeEach', fileRelative);
 
   return true;
 };
 
 export const afterEach = async (fileRelative: string) => {
-  if (GLOBAL.configs.afterEach)
-    return await eachCore('afterEach', fileRelative);
+  if (GLOBAL.configs.afterEach) return eachCore('afterEach', fileRelative);
 
   return true;
 };

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -74,5 +74,5 @@ export const runTests = async (dir: string): Promise<boolean> => {
   for (let i = 0; i < concurrency; i++)
     isSequential ? await runNext() : runNext();
 
-  return await done;
+  return done;
 };


### PR DESCRIPTION
Just a simple refactoring, since the `await` is already used by the caller of the respective methods and we can just return the promise directly.

Let's see if it affects the benchmark in any way.