### PR TITLE
fix: ensure concurrency for multiple inputs

### DIFF
--- a/src/modules/essentials/poku.ts
+++ b/src/modules/essentials/poku.ts
@@ -37,11 +37,11 @@ export async function poku(
   const { reporter: plugin } = GLOBAL.configs;
   const { cwd } = GLOBAL;
 
-  const testFiles = [
-    ...(await Promise.all(
+  const testFiles = (
+    await Promise.all(
       paths.map((dir) => listFiles(join(cwd, dir), GLOBAL.configs))
-    )),
-  ].flat();
+    )
+  ).flat(1);
 
   if (typeof plugin === 'string' && plugin !== 'poku')
     GLOBAL.reporter = reporter[plugin]();

--- a/src/modules/essentials/poku.ts
+++ b/src/modules/essentials/poku.ts
@@ -1,10 +1,12 @@
 import type { Code } from '../../@types/code.js';
 import type { Configs } from '../../@types/poku.js';
+import { join } from 'node:path';
 import process from 'node:process';
 import { GLOBAL, results, timespan } from '../../configs/poku.js';
 import { reporter } from '../../services/reporter.js';
 import { runTests } from '../../services/run-tests.js';
 import { exit } from '../helpers/exit.js';
+import { listFiles } from '../helpers/list-files.js';
 
 /* c8 ignore next 1 */ // Process-based
 export const onSigint = () => process.stdout.write('\u001B[?25h');
@@ -33,17 +35,25 @@ export async function poku(
   const paths: string[] = Array.prototype.concat(targetPaths);
   const showLogs = !GLOBAL.configs.quiet;
   const { reporter: plugin } = GLOBAL.configs;
+  const { cwd } = GLOBAL;
+
+  const testFiles = [
+    ...(await Promise.all(
+      paths.map((dir) => listFiles(join(cwd, dir), configs))
+    )),
+  ].flat();
 
   if (typeof plugin === 'string' && plugin !== 'poku')
     GLOBAL.reporter = reporter[plugin]();
 
-  if (showLogs) GLOBAL.reporter.onRunStart();
-
   try {
-    const promises = paths.map(async (dir) => await runTests(dir));
-    const concurrency = await Promise.all(promises);
+    if (showLogs) GLOBAL.reporter.onRunStart();
 
-    if (concurrency.some((result) => !result)) code = 1;
+    const result = await runTests(testFiles);
+
+    if (!result) code = 1;
+  } catch {
+    code = 1;
   } finally {
     const end = process.hrtime(start);
     const total = end[0] * 1e3 + end[1] / 1e6;

--- a/src/modules/essentials/poku.ts
+++ b/src/modules/essentials/poku.ts
@@ -25,8 +25,6 @@ export async function poku(
   targetPaths: string | string[],
   configs?: Configs
 ): Promise<Code | undefined> {
-  let code: Code = 0;
-
   if (configs) GLOBAL.configs = { ...GLOBAL.configs, ...configs };
 
   timespan.started = new Date();
@@ -46,21 +44,15 @@ export async function poku(
   if (typeof plugin === 'string' && plugin !== 'poku')
     GLOBAL.reporter = reporter[plugin]();
 
-  try {
-    if (showLogs) GLOBAL.reporter.onRunStart();
+  if (showLogs) GLOBAL.reporter.onRunStart();
 
-    const result = await runTests(testFiles);
+  const result = await runTests(testFiles);
+  const code: Code = result ? 0 : 1;
+  const end = process.hrtime(start);
+  const total = end[0] * 1e3 + end[1] / 1e6;
 
-    if (!result) code = 1;
-  } catch {
-    code = 1;
-  } finally {
-    const end = process.hrtime(start);
-    const total = end[0] * 1e3 + end[1] / 1e6;
-
-    timespan.duration = total;
-    timespan.finished = new Date();
-  }
+  timespan.duration = total;
+  timespan.finished = new Date();
 
   if (showLogs) GLOBAL.reporter.onRunResult({ code, timespan, results });
   if (GLOBAL.configs.noExit) return code;

--- a/src/modules/essentials/poku.ts
+++ b/src/modules/essentials/poku.ts
@@ -39,7 +39,7 @@ export async function poku(
 
   const testFiles = [
     ...(await Promise.all(
-      paths.map((dir) => listFiles(join(cwd, dir), configs))
+      paths.map((dir) => listFiles(join(cwd, dir), GLOBAL.configs))
     )),
   ].flat();
 

--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -1,7 +1,6 @@
-import { join, relative } from 'node:path';
-import process from 'node:process';
+import { relative } from 'node:path';
+import { exit } from 'node:process';
 import { deepOptions, GLOBAL, results } from '../configs/poku.js';
-import { listFiles } from '../modules/helpers/list-files.js';
 import { hasOnly } from '../parsers/get-arg.js';
 import { availableParallelism } from '../polyfills/os.js';
 import { hr, log } from '../services/write.js';
@@ -12,14 +11,12 @@ const { cwd } = GLOBAL;
 
 if (hasOnly) deepOptions.push('--only');
 
-export const runTests = async (dir: string): Promise<boolean> => {
+export const runTests = async (files: string[]): Promise<boolean> => {
   let allPassed = true;
   let activeTests = 0;
   let resolveDone: (value: boolean) => void;
 
   const { configs } = GLOBAL;
-  const testDir = join(cwd, dir);
-  const files = await listFiles(testDir, configs);
   const showLogs = !configs.quiet;
   const failFastError = `  ${format('ℹ').fail()} ${format('failFast').bold()} is enabled`;
   const concurrency: number = (() => {
@@ -62,7 +59,7 @@ export const runTests = async (dir: string): Promise<boolean> => {
           hr();
         }
 
-        process.exit(1);
+        exit(1);
       }
     }
 

--- a/test/__fixtures__/e2e/sequential/a.test.ts
+++ b/test/__fixtures__/e2e/sequential/a.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { assert, test } from '../../../../src/modules/index.js';
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { test } from '../../../../src/modules/helpers/test.js';
 
 test(async () => {
   const testDir = '../../.temp/sequential';

--- a/test/__fixtures__/e2e/sequential/b.test.ts
+++ b/test/__fixtures__/e2e/sequential/b.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { assert, test } from '../../../../src/modules/index.js';
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { test } from '../../../../src/modules/helpers/test.js';
 
 test(async () => {
   const testDir = '../../.temp/sequential';

--- a/test/__fixtures__/e2e/sequential/c.test.ts
+++ b/test/__fixtures__/e2e/sequential/c.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { assert, test } from '../../../../src/modules/index.js';
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { test } from '../../../../src/modules/helpers/test.js';
 
 test(async () => {
   const testDir = '../../.temp/sequential';

--- a/test/__fixtures__/e2e/sequential/d.test.ts
+++ b/test/__fixtures__/e2e/sequential/d.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { assert, test } from '../../../../src/modules/index.js';
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { test } from '../../../../src/modules/helpers/test.js';
 
 test(async () => {
   const testDir = '../../.temp/sequential';

--- a/test/__fixtures__/e2e/sequential/e.test.ts
+++ b/test/__fixtures__/e2e/sequential/e.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { assert, test } from '../../../../src/modules/index.js';
+import { assert } from '../../../../src/modules/essentials/assert.js';
+import { test } from '../../../../src/modules/helpers/test.js';
 
 test(async () => {
   const testDir = '../../.temp/sequential';

--- a/test/e2e/concurrency.test.ts
+++ b/test/e2e/concurrency.test.ts
@@ -2,17 +2,15 @@ import { inspectPoku } from '../__utils__/capture-cli.test.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { test } from '../../src/modules/helpers/test.js';
 
-test('Start 30 servers on the same port 10 times', async () => {
-  for (let i = 0; i < 10; i++) {
-    const results = await inspectPoku('-d --sequential', {
-      cwd: 'test/__fixtures__/e2e/concurrency/sequence',
-    });
+test('Start 30 servers on the same port', async () => {
+  const results = await inspectPoku('-d --sequential', {
+    cwd: 'test/__fixtures__/e2e/concurrency/sequence',
+  });
 
-    if (results.exitCode !== 0) {
-      console.log(results.stdout);
-      console.log(results.stderr);
-    }
-
-    assert.strictEqual(results.exitCode, 0);
+  if (results.exitCode !== 0) {
+    console.log(results.stdout);
+    console.log(results.stderr);
   }
+
+  assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
 });

--- a/test/e2e/concurrency.test.ts
+++ b/test/e2e/concurrency.test.ts
@@ -1,19 +1,18 @@
-import { inspectPoku, isBuild } from '../__utils__/capture-cli.test.js';
+import { inspectPoku } from '../__utils__/capture-cli.test.js';
 import { assert } from '../../src/modules/essentials/assert.js';
-import { skip } from '../../src/modules/helpers/skip.js';
 import { test } from '../../src/modules/helpers/test.js';
 
-if (isBuild) skip();
+test('Start 30 servers on the same port 10 times', async () => {
+  for (let i = 0; i < 10; i++) {
+    const results = await inspectPoku('-d --sequential', {
+      cwd: 'test/__fixtures__/e2e/concurrency/sequence',
+    });
 
-test('Start 30 servers on the same port', async () => {
-  const results = await inspectPoku('--killPort=8000 -d --sequential', {
-    cwd: 'test/__fixtures__/e2e/concurrency/sequence',
-  });
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
 
-  if (results.exitCode !== 0) {
-    console.log(results.stdout);
-    console.log(results.stderr);
+    assert.strictEqual(results.exitCode, 0);
   }
-
-  assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
 });

--- a/test/e2e/runners.test.ts
+++ b/test/e2e/runners.test.ts
@@ -70,7 +70,7 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
   hasDeno &&
     (await it('Deno', async () => {
       const output = await inspectCLI(
-        'deno run --unstable-sloppy-imports --allow-read --allow-env --allow-run src/bin/index.ts test/__fixtures__/e2e/extensions -d --exclude=.cts'
+        'deno run --unstable-sloppy-imports --allow-read --allow-env --allow-run src/bin/index.ts test/__fixtures__/e2e/extensions -d'
       );
 
       if (output.exitCode !== 0) {
@@ -79,7 +79,7 @@ describe('Test Runtimes/Platforms + Extensions', async () => {
       }
 
       assert.strictEqual(output.exitCode, 0, 'Exit Code needs to be 0');
-      assert(/PASS › 10/.test(output.stdout), 'CLI needs to pass 10');
+      assert(/PASS › 12/.test(output.stdout), 'CLI needs to pass 12');
       assert(/FAIL › 0/.test(output.stdout), 'CLI needs to fail 0');
     }));
 });

--- a/test/e2e/sequential.test.ts
+++ b/test/e2e/sequential.test.ts
@@ -1,20 +1,22 @@
-import { inspectPoku, isBuild } from '../__utils__/capture-cli.test.js';
+import { inspectPoku } from '../__utils__/capture-cli.test.js';
 import { GLOBAL } from '../../src/configs/poku.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { skip } from '../../src/modules/helpers/skip.js';
 
-if (GLOBAL.runtime === 'deno' || isBuild) skip();
+if (GLOBAL.runtime === 'deno') skip();
 
-describe('Ensure sequential runs', async () => {
-  const results = await inspectPoku('--debug --sequential', {
-    cwd: 'test/__fixtures__/e2e/sequential',
-  });
+describe('Ensure sequential runs 10 times', async () => {
+  for (let i = 0; i < 10; i++) {
+    const results = await inspectPoku('--debug --sequential', {
+      cwd: 'test/__fixtures__/e2e/sequential',
+    });
 
-  if (results.exitCode !== 0) {
-    console.log(results.stdout);
-    console.log(results.stderr);
+    if (results.exitCode !== 0) {
+      console.log(results.stdout);
+      console.log(results.stderr);
+    }
+
+    assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
   }
-
-  assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
 });

--- a/test/e2e/sequential.test.ts
+++ b/test/e2e/sequential.test.ts
@@ -6,17 +6,15 @@ import { skip } from '../../src/modules/helpers/skip.js';
 
 if (GLOBAL.runtime === 'deno') skip();
 
-describe('Ensure sequential runs 10 times', async () => {
-  for (let i = 0; i < 10; i++) {
-    const results = await inspectPoku('--debug --sequential', {
-      cwd: 'test/__fixtures__/e2e/sequential',
-    });
+describe('Ensure sequential runs', async () => {
+  const results = await inspectPoku('--debug --sequential', {
+    cwd: 'test/__fixtures__/e2e/sequential',
+  });
 
-    if (results.exitCode !== 0) {
-      console.log(results.stdout);
-      console.log(results.stderr);
-    }
-
-    assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
+  if (results.exitCode !== 0) {
+    console.log(results.stdout);
+    console.log(results.stderr);
   }
+
+  assert.strictEqual(results.exitCode, 0, 'Exit Code needs to be 0');
 });

--- a/test/integration/wait-for/wait-for-port.test.ts
+++ b/test/integration/wait-for/wait-for-port.test.ts
@@ -21,12 +21,12 @@ const stopServer = (server: Server): Promise<void> =>
 
 test('Wait For Port', async () => {
   try {
-    await kill.range(8000, 8003);
+    await kill.range(8001, 8004);
   } catch {}
 
   await Promise.all([
     it(async () => {
-      const port = 8000;
+      const port = 8001;
       const server = await startServer(port);
 
       try {
@@ -40,7 +40,7 @@ test('Wait For Port', async () => {
     }),
 
     it(async () => {
-      const port = 8001;
+      const port = 8002;
       const server = await startServer(port);
 
       try {
@@ -54,7 +54,7 @@ test('Wait For Port', async () => {
     }),
 
     it(async () => {
-      const port = 8002;
+      const port = 8003;
 
       try {
         await waitForPort(port, { timeout: 1000 });
@@ -69,7 +69,7 @@ test('Wait For Port', async () => {
     }),
 
     it(async () => {
-      const port = 8003;
+      const port = 8004;
       const server = await startServer(port);
 
       try {
@@ -97,6 +97,6 @@ test('Wait For Port', async () => {
   ]);
 
   try {
-    await kill.range(8000, 8003);
+    await kill.range(8001, 8004);
   } catch {}
 });

--- a/test/unit/run-tests.test.ts
+++ b/test/unit/run-tests.test.ts
@@ -2,6 +2,7 @@ import { GLOBAL } from '../../src/configs/poku.js';
 import { assert } from '../../src/modules/essentials/assert.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { it } from '../../src/modules/helpers/it/core.js';
+import { listFiles } from '../../src/modules/helpers/list-files.js';
 import { runTests } from '../../src/services/run-tests.js';
 
 GLOBAL.configs.noExit = true;
@@ -10,13 +11,17 @@ GLOBAL.configs.quiet = true;
 describe('Service: runTests', async () => {
   await Promise.all([
     it(async () => {
-      const code = await runTests('test/__fixtures__/e2e/fail');
+      const code = await runTests(
+        await listFiles('test/__fixtures__/e2e/fail')
+      );
 
       assert.deepStrictEqual(code, false, 'Failure test directory case');
     }),
 
     it(async () => {
-      const code = await runTests('test/__fixtures__/e2e/success');
+      const code = await runTests(
+        await listFiles('test/__fixtures__/e2e/success')
+      );
 
       assert.deepStrictEqual(code, true, 'Success test directory case');
     }),


### PR DESCRIPTION
Fixes #958.

---

When multiple inputs are specified, the concurrence limit between the inputs isn't respected. For example:

```sh
poku dirA dirB
```

- Currently, directories A and B will be triggered at the same time, where each one will perform the concurrency limit between their files, but not between each other.