### PR TITLE
docs: remove highlight of migrating from previous version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,6 @@ Enjoying **Poku**? Give him a star to show your support 🌟
 
 </div>
 
-> [!IMPORTANT]
->
-> **Poku `v3`** is here! 🎉
->
-> - To check out what's changed, follow the [**Issue #801**](https://github.com/wellwelwel/poku/issues/801).
-> - For `v2` documentation, see the [**previous version's documentation**](https://poku.io/docs/2.x.x) and [**README**](https://github.com/wellwelwel/poku/tree/2.x.x?tab=readme-ov-file#readme).<br />
-
 ---
 
 ## Why does Poku exist?

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -35,20 +35,11 @@ Enjoying **Poku**? [Give him a star to show your support](https://github.com/wel
 
 <hr />
 
-:::tip Announcement
-
-**Poku `v3`** is here! 🎉
-
-- To check out what's changed, follow the [**Issue #801**](https://github.com/wellwelwel/poku/issues/801).
-- For `v2` documentation, see the [**previous version's documentation**](/docs/2.x.x).<br />
-
-:::
-
 ### 🧑🏻‍🎓 Recommended Roadmap
 
 1. [Install **Poku**](/docs#install). <br />
 2. See [how to use **assertions**](/docs/tutorials/beginner). <br />
-3. Then learn how to use [**poku**](/docs/documentation/poku/include-files) to **run all your test files** at once.
+3. Then learn how to use [**Poku**](/docs/documentation/poku/include-files) to **run all your test files** at once.
 
 > 🧑🏻‍🔬 Need to test an _API_? Check the [startService](/docs/documentation/helpers/startService) and [startScript](/docs/documentation/helpers/startScript). <br />
 > 🚪 Need to handle processes and ports? Check the [kill](/docs/documentation/helpers/processes/kill) and [waitForPort](/docs/documentation/helpers/processes/wait-for-port). <br />

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
@@ -35,20 +35,11 @@ Curtindo **Poku**? [Dê a ele uma estrela para mostrar seu apoio](https://github
 
 <hr />
 
-:::tip Comunicado
-
-**Poku `v3`** chegou! 🎉
-
-- Para conferir o que mudou, siga o [**Issue #801**](https://github.com/wellwelwel/poku/issues/801).
-- Para obter a documentação da `v2`, consulte a [**documentação da versão anterior**](/docs/2.x.x).<br />
-
-:::
-
 ### 🧑🏻‍🎓 Guia Recomendado
 
 1. [Instale o **Poku**](/docs#instalação). <br />
 2. Veja [como usar **asserções**](/docs/tutorials/beginner). <br />
-3. Em seguida, aprenda a usar o [**poku**](/docs/documentation/poku/include-files) para **executar todos os seus arquivos de teste** de uma só vez.
+3. Em seguida, aprenda a usar o [**Poku**](/docs/documentation/poku/include-files) para **executar todos os seus arquivos de teste** de uma só vez.
 
 > 🧑🏻‍🔬 Precisa testar uma _API_? Verifique o [startService](/docs/documentation/helpers/startService) e o [startScript](/docs/documentation/helpers/startScript). <br />
 > 🚪 Precisa lidar com processos e portas? Verifique o [kill](/docs/documentation/helpers/processes/kill) e o [waitForPort](/docs/documentation/helpers/processes/wait-for-port). <br />


### PR DESCRIPTION
The migration across versions can be checked out in the "Common Issues" section:

- https://github.com/wellwelwel/poku?tab=readme-ov-file#common-issues