### PR TITLE
fix: defer execution of shared resource cleanup to after all tests complete

### DIFF
--- a/src/services/run-tests.ts
+++ b/src/services/run-tests.ts
@@ -49,14 +49,16 @@ export const runTests = async (files: string[]): Promise<boolean> => {
   const isSequential = concurrency === 1;
 
   const done = new Promise<boolean>((resolve) => {
-    resolveDone = resolve;
+    resolveDone = (passed: boolean) => {
+      resolve(passed);
 
-    if (!GLOBAL.configs.sharedResources) return;
+      if (!GLOBAL.configs.sharedResources) return;
 
-    const entries = Object.entries(cleanupMethods!);
+      const entries = Object.entries(cleanupMethods!);
 
-    for (const [key, method] of entries)
-      method(registry![key].state as SharedResourceEntry);
+      for (const [key, method] of entries)
+        method(registry![key].state as SharedResourceEntry);
+    };
   });
 
   const runNext = async () => {


### PR DESCRIPTION
This pull request makes a minor update to the `runTests` function in `src/services/run-tests.ts`. The change ensures that shared resource cleanup only occurs after the test completion promise is resolved, and that the resolved value is properly passed through.