### PR TITLE
fix: remove dead portBackup variable that prevented port cleanup on SIGINT

### DIFF
--- a/src/modules/helpers/create-service.ts
+++ b/src/modules/helpers/create-service.ts
@@ -12,8 +12,7 @@ import { log } from '../../services/write.js';
 import { kill } from './kill.js';
 import { sanitizePath } from './list-files.js';
 
-const runningProcesses: Map<number, { end: End; port?: number | number[] }> =
-  new Map();
+const runningProcesses: Map<number, End> = new Map();
 
 const backgroundProcess = (
   runtime: string,
@@ -39,8 +38,6 @@ const backgroundProcess = (
 
       service.stdout.setEncoding('utf8');
       service.stderr.setEncoding('utf8');
-
-      let portBackup: number | undefined;
 
       const end: End = (port) =>
         new Promise((resolve) => {
@@ -75,7 +72,7 @@ const backgroundProcess = (
           }
         });
 
-      runningProcesses.set(PID, { end, port: portBackup });
+      runningProcesses.set(PID, end);
 
       service.stdout.on('data', (data: Buffer) => {
         if (!isResolved && typeof options?.startAfter !== 'number') {
@@ -116,7 +113,7 @@ const backgroundProcess = (
       });
 
       service.on('error', (err) => {
-        end(portBackup);
+        end();
         reject(`Service failed to start: ${err}`);
       });
 
@@ -126,7 +123,7 @@ const backgroundProcess = (
 
       const timeout = setTimeout(() => {
         if (!isResolved) {
-          end(portBackup);
+          end();
           reject(`createService: Timeout\nFile: ${file}`);
         }
       }, options?.timeout || 60000);
@@ -184,5 +181,5 @@ export const startScript = (
 };
 
 process.once('SIGINT', async () => {
-  for (const { end, port } of runningProcesses.values()) await end(port);
+  for (const end of runningProcesses.values()) await end();
 });


### PR DESCRIPTION
## Problem

The `portBackup` variable in `src/modules/helpers/create-service.ts` was declared but never assigned a value, meaning it was always `undefined`.

This caused:
1. `runningProcesses` map stored `port: undefined`, so **SIGINT cleanup never killed ports on Bun/Deno**
2. Error and timeout handlers passed `portBackup` (undefined) to `end()`, skipping port cleanup there too

The code *looked* like it handled port cleanup on SIGINT, but it never actually did.

## Solution

Remove the dead `portBackup` variable and simplify the code to be honest about what it can and cannot do:

- Remove the never-assigned `portBackup` variable
- Simplify `runningProcesses` from `Map<number, {end, port}>` to `Map<number, End>`
- Call `end()` without port in error/timeout/SIGINT handlers
- Port cleanup remains the caller's responsibility — the `End` type already accepts an optional `port` parameter, so callers who know the port can still pass it

## Files Changed

- `src/modules/helpers/create-service.ts` — removed dead variable, simplified map type, updated callers