### PR TITLE
feat: capture stderr output in run-test-in-process (isolation: none)

### DIFF
--- a/src/services/run-test-in-process.ts
+++ b/src/services/run-test-in-process.ts
@@ -7,14 +7,23 @@ import { afterEach, beforeEach } from './each.js';
 import { format } from './format.js';
 
 const stdoutWrite = process.stdout.write.bind(process.stdout);
+const stderrWrite = process.stderr.write.bind(process.stderr);
 
 const cleanup = () => {
   process.stdout.write = stdoutWrite;
+  process.stderr.write = stderrWrite;
   process.exitCode = 0;
 };
 
 const mockProcess = (outputChunks: string[]) => {
   process.stdout.write = (
+    chunk: string | Uint8Array,
+    ..._args: unknown[]
+  ): boolean => {
+    outputChunks.push(String(chunk));
+    return true;
+  };
+  process.stderr.write = (
     chunk: string | Uint8Array,
     ..._args: unknown[]
   ): boolean => {


### PR DESCRIPTION
## Problem

When running tests with `isolation: 'none'`, only `process.stdout.write` was mocked to capture test output. This meant `console.error` and other stderr output from test code would leak directly to the terminal instead of being captured and parsed by the reporter.

The default `isolation: 'process'` mode captures all output via child process pipes, so this was a gap specific to the in-process runner.

## Solution

Mock both `process.stdout.write` and `process.stderr.write` in `mockProcess()`, and restore both in `cleanup()`. This ensures all test output is captured regardless of which stream it is written to, matching the behavior of isolated process mode.

## Files Changed

- `src/services/run-test-in-process.ts` — added stderr mock alongside stdout mock