### PR TITLE
fix: include template literal paths in watch mode dependency mapping

### DIFF
--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -1,7 +1,7 @@
-import type { ScopeHook } from '../../../@types/plugin.js';
-import type { TestCallback } from '../../../@types/poku.js';
 import { AssertionError } from 'node:assert';
 import process from 'node:process';
+import type { ScopeHook } from '../../../@types/plugin.js';
+import type { TestCallback } from '../../../@types/poku.js';
 import { each } from '../../../configs/each.js';
 import { indentation } from '../../../configs/indentation.js';
 import { errorHoist, GLOBAL } from '../../../configs/poku.js';
@@ -138,11 +138,6 @@ async function itCore(
 
   if (hasOnly) {
     if (!GLOBAL.runAsOnly) return;
-
-    if (typeof titleOrCb === 'string' && typeof cb === 'function')
-      return itBase(titleOrCb, cb);
-
-    if (typeof titleOrCb === 'function') return itBase(titleOrCb);
   }
 
   if (typeof titleOrCb === 'string' && cb) return itBase(titleOrCb, cb);

--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -1,7 +1,7 @@
-import { AssertionError } from 'node:assert';
-import process from 'node:process';
 import type { ScopeHook } from '../../../@types/plugin.js';
 import type { TestCallback } from '../../../@types/poku.js';
+import { AssertionError } from 'node:assert';
+import process from 'node:process';
 import { each } from '../../../configs/each.js';
 import { indentation } from '../../../configs/indentation.js';
 import { errorHoist, GLOBAL } from '../../../configs/poku.js';

--- a/src/services/map-tests.ts
+++ b/src/services/map-tests.ts
@@ -4,7 +4,7 @@ import { listFiles } from '../modules/helpers/list-files.js';
 
 const regex = {
   extFilter: /\.(js|cjs|mjs|ts|cts|mts)$/,
-  dependecy: /['"](\.{1,2}\/[^'"]+)['"]/,
+  dependency: /['"`](\.{1,2}\/[^'"`]+)['"`]/,
   dotBar: /(\.\/)/g,
   sep: /[/\\]+/g,
   dot: /^\.+/,
@@ -26,7 +26,7 @@ export const getDeepImports = (content: string): Set<string> => {
       line.indexOf('require') !== -1 ||
       line.indexOf(' from ') !== -1
     ) {
-      const path = line.match(regex.dependecy);
+      const path = line.match(regex.dependency);
 
       if (path) paths.add(normalizePath(path[1].replace(regex.extFilter, '')));
     }

--- a/test/unit/map-tests.test.ts
+++ b/test/unit/map-tests.test.ts
@@ -183,6 +183,21 @@ test(async () => {
         ]),
         'require'
       );
+
+      assert.deepStrictEqual(
+        getDeepImports(
+          `
+          import { some } from './a';
+          const { some } = require('./b');
+          import('./c');
+          const mod = await import(\`./d\`);
+          import { some } from \`./e\`;
+          require(\`./f.js\`);
+          `
+        ),
+        new Set(['a', 'b', 'c', 'd', 'e', 'f']),
+        'template literals'
+      );
     });
   });
 


### PR DESCRIPTION
### Problem

 Watch mode (poku --watch) builds a source→test dependency map using getDeepImports from src/services/map-tests.ts. The dependency regex only
 matched paths in single or double quotes:

 ```ts
   dependency: /['"](\.{1,2}\/[^'"]+)['"]/,
 ```

 Dynamic imports with template literals were invisible:

 ```js
   const { greet } = await import(`./utils.js`);  // ❌ not detected
 ```

 This meant editing utils.js would not trigger a test re-run, breaking the watch mode workflow for any project using dynamic imports.

 ### Changes

 - src/services/map-tests.ts — Extended regex character classes from ['"] to ['"\]` to also match backtick-delimited paths
 - test/unit/map-tests.test.ts — Added "template literals" test case covering import(\./d`), `` import from ./e ``, and `` require(\./f`) ``
 - src/modules/helpers/it/core.ts — Removed duplicated itBase calls inside the hasOnly block that were identical to the common path below (dead
 code; no behavior change)

 ### Before / After

 ```js
   // getDeepImports(`import(\`./utils.js\`)`)
   // Before: Set(0) {}        ← path missed
   // After:  Set(1) { 'utils' } ← path detected
 ```