### PR TITLE
fix: resolve TDZ circular dependencies

### DIFF
--- a/.github/workflows/ci_lint.yml
+++ b/.github/workflows/ci_lint.yml
@@ -39,4 +39,9 @@ jobs:
         run: npm ci
 
       - name: 🤹🏻‍♀️ Biome + Prettier Check
+        if: always()
         run: npm run lint
+
+      - name: 🚫 Type Declarations Check
+        if: always()
+        run: npm run lint:types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ On a fork, ALWAYS read `CONTRIBUTING.md` before committing.
 
 Run these scripts:
 
+- `npm run lint:types`
 - `npm run lint:fix`
 - `npm run build`
 - `npm test`: full suite on local Node.js version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "monocart-coverage-reports": "^2.12.11",
         "packages-update": "^2.0.0",
         "prettier": "^3.8.3",
+        "rollup": "^4.60.4",
+        "rollup-plugin-dts": "^6.4.1",
         "tsx": "^4.22.0",
         "typescript": "^6.0.3"
       },
@@ -863,6 +865,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -947,6 +960,402 @@
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1655,6 +2064,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -1893,6 +2312,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz",
+      "integrity": "sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "convert-source-map": "^2.0.0",
+        "magic-string": "^0.30.21"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.29.0"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0 || ^6.0"
       }
     },
     "node_modules/rxjs": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
   "version": "4.3.1",
   "description": "🐷 Poku makes testing easy for Node.js, Bun, Deno, and you at the same time.",
   "main": "./lib/modules/index.js",
+  "types": "./lib/modules/index.d.ts",
   "exports": {
-    ".": "./lib/modules/index.js",
-    "./plugins": "./lib/modules/plugins.js"
+    ".": {
+      "types": "./lib/modules/index.d.ts",
+      "default": "./lib/modules/index.js"
+    },
+    "./plugins": {
+      "types": "./lib/modules/plugins.d.ts",
+      "default": "./lib/modules/plugins.js"
+    }
   },
   "license": "MIT",
   "bin": {
@@ -42,6 +49,7 @@
     "build": "bash scripts/build.sh",
     "lint": "bash scripts/lint.sh",
     "lint:fix": "bash scripts/lint-fix.sh",
+    "lint:types": "bash scripts/lint-types.sh",
     "update": "bash scripts/update.sh",
     "benchmark": "npm --prefix benchmark start"
   },
@@ -56,6 +64,8 @@
     "monocart-coverage-reports": "^2.12.11",
     "packages-update": "^2.0.0",
     "prettier": "^3.8.3",
+    "rollup": "^4.60.4",
+    "rollup-plugin-dts": "^6.4.1",
     "tsx": "^4.22.0",
     "typescript": "^6.0.3"
   },

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,8 +12,9 @@ echo '◉ build'
 
 echo '◯ postbuild'
 concurrently \
-  -n "version,fixtures,cleanup,chmod" \
+  -n "version,dts,fixtures,cleanup,chmod" \
   "tsx tools/build/version.ts" \
+  "tsx tools/build/dts.mts" \
   "cp test/__fixtures__/e2e/server/package.json ci/test/__fixtures__/e2e/server/package.json" \
   "rm -f ./lib/@types/*.js ./lib/bin/*.ts" \
   "chmod +x lib/bin/index.js"

--- a/scripts/lint-types.sh
+++ b/scripts/lint-types.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+repositoryRoot="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+typeViolations="$(
+  grep -rE '^(export )?(type|interface) [A-Z]' \
+    "$repositoryRoot/src" \
+    --include='*.ts' \
+    | grep -v '/@types/' \
+    || true
+)"
+
+if [[ -n "$typeViolations" ]]; then
+  echo "Forbidden type declarations found outside src/@types/:" >&2
+  printf '%s\n' "$typeViolations" >&2
+  exit 1
+fi
+
+doubleCastHits="$(
+  cd "$repositoryRoot" && find . \
+    \( -path './.git' -o -name 'node_modules' -o -path './lib' \) -prune -o \
+    -type f \( -name '*.ts' -o -name '*.mts' -o -name '*.cts' \) \
+    -print0 \
+    | xargs -0 grep -nF 'as unknown as' \
+    || true
+)"
+
+if [[ -n "$doubleCastHits" ]]; then
+  echo "Forbidden \"as unknown as\" double-cast found:" >&2
+  printf '%s\n' "$doubleCastHits" >&2
+  exit 1
+fi

--- a/src/@types/assert.ts
+++ b/src/@types/assert.ts
@@ -1,3 +1,5 @@
+import type { AssertPredicate } from 'node:assert';
+
 export type ProcessAssertionOptions = {
   message?: string | Error;
   defaultMessage?: string;
@@ -5,4 +7,40 @@ export type ProcessAssertionOptions = {
   expected?: string;
   throw?: boolean;
   hideDiff?: boolean;
+};
+
+export type AssertionMessage = ProcessAssertionOptions['message'];
+
+export type AssertValue = (value: unknown, message?: AssertionMessage) => void;
+
+export type AssertEqual = (
+  actual: unknown,
+  expected: unknown,
+  message?: AssertionMessage
+) => void;
+
+export type AssertMatch = (
+  value: string,
+  regExp: RegExp,
+  message?: AssertionMessage
+) => void;
+
+export type AsyncBlock = (() => Promise<unknown>) | Promise<unknown>;
+
+export type AssertThrows = {
+  (block: () => unknown, message?: AssertionMessage): void;
+  (
+    block: () => unknown,
+    error: AssertPredicate,
+    message?: AssertionMessage
+  ): void;
+};
+
+export type AssertRejects = {
+  (block: AsyncBlock, message?: AssertionMessage): Promise<void>;
+  (
+    block: AsyncBlock,
+    error: AssertPredicate,
+    message?: AssertionMessage
+  ): Promise<void>;
 };

--- a/src/@types/describe.ts
+++ b/src/@types/describe.ts
@@ -1,6 +1,5 @@
 import type { backgroundColor } from '../services/format.js';
-import type { Modifier, Todo } from './modifiers.js';
-import type { AsyncTestCallback, TestCallback } from './poku.js';
+import type { AsyncTestCb, TestCb } from './poku.js';
 
 export type DescribeOptions = {
   background?: keyof typeof backgroundColor | boolean;
@@ -11,15 +10,9 @@ export type DescribeOptions = {
 };
 
 export type Describe = {
-  (message: string, cb: AsyncTestCallback): Promise<void>;
-  (message: string, cb: TestCallback): void;
-  (cb: AsyncTestCallback): Promise<void>;
-  (cb: TestCallback): void;
+  (message: string, cb: AsyncTestCb): Promise<void>;
+  (message: string, cb: TestCb): void;
+  (cb: AsyncTestCb): Promise<void>;
+  (cb: TestCb): void;
   (message: string, options?: DescribeOptions): void;
-};
-
-export type DescribeWithModifiers = Describe & {
-  todo: Todo;
-  skip: Modifier;
-  only: Modifier;
 };

--- a/src/@types/describe.ts
+++ b/src/@types/describe.ts
@@ -1,4 +1,6 @@
 import type { backgroundColor } from '../services/format.js';
+import type { Modifier, Todo } from './modifiers.js';
+import type { AsyncTestCallback, TestCallback } from './poku.js';
 
 export type DescribeOptions = {
   background?: keyof typeof backgroundColor | boolean;
@@ -6,4 +8,18 @@ export type DescribeOptions = {
    * @default "☰"
    */
   icon?: string;
+};
+
+export type Describe = {
+  (message: string, cb: AsyncTestCallback): Promise<void>;
+  (message: string, cb: TestCallback): void;
+  (cb: AsyncTestCallback): Promise<void>;
+  (cb: TestCallback): void;
+  (message: string, options?: DescribeOptions): void;
+};
+
+export type DescribeWithModifiers = Describe & {
+  todo: Todo;
+  skip: Modifier;
+  only: Modifier;
 };

--- a/src/@types/it.ts
+++ b/src/@types/it.ts
@@ -1,15 +1,8 @@
-import type { Modifier, Todo } from './modifiers.js';
-import type { AsyncTestCallback, TestCallback } from './poku.js';
+import type { AsyncTestCb, TestCb } from './poku.js';
 
 export type It = {
-  (title: string, cb: AsyncTestCallback): Promise<void>;
-  (title: string, cb: TestCallback): void;
-  (cb: AsyncTestCallback): Promise<void>;
-  (cb: TestCallback): void;
-};
-
-export type ItWithModifiers = It & {
-  todo: Todo;
-  skip: Modifier;
-  only: Modifier;
+  (title: string, cb: AsyncTestCb): Promise<void>;
+  (title: string, cb: TestCb): void;
+  (cb: AsyncTestCb): Promise<void>;
+  (cb: TestCb): void;
 };

--- a/src/@types/it.ts
+++ b/src/@types/it.ts
@@ -1,0 +1,15 @@
+import type { Modifier, Todo } from './modifiers.js';
+import type { AsyncTestCallback, TestCallback } from './poku.js';
+
+export type It = {
+  (title: string, cb: AsyncTestCallback): Promise<void>;
+  (title: string, cb: TestCallback): void;
+  (cb: AsyncTestCallback): Promise<void>;
+  (cb: TestCallback): void;
+};
+
+export type ItWithModifiers = It & {
+  todo: Todo;
+  skip: Modifier;
+  only: Modifier;
+};

--- a/src/@types/modifiers.ts
+++ b/src/@types/modifiers.ts
@@ -1,14 +1,14 @@
-import type { AsyncTestCallback, TestCallback } from './poku.js';
+import type { AsyncTestCb, TestCb } from './poku.js';
 
 export type Todo = {
   (message: string): void;
-  (message: string, cb?: AsyncTestCallback): Promise<void>;
-  (message: string, cb?: TestCallback): void;
+  (message: string, cb?: AsyncTestCb): Promise<void>;
+  (message: string, cb?: TestCb): void;
 };
 
 export type Modifier = {
-  (message: string, cb: AsyncTestCallback): Promise<void>;
-  (message: string, cb: TestCallback): void;
-  (cb: AsyncTestCallback): Promise<void>;
-  (cb: TestCallback): void;
+  (message: string, cb: AsyncTestCb): Promise<void>;
+  (message: string, cb: TestCb): void;
+  (cb: AsyncTestCb): Promise<void>;
+  (cb: TestCb): void;
 };

--- a/src/@types/modifiers.ts
+++ b/src/@types/modifiers.ts
@@ -1,0 +1,14 @@
+import type { AsyncTestCallback, TestCallback } from './poku.js';
+
+export type Todo = {
+  (message: string): void;
+  (message: string, cb?: AsyncTestCallback): Promise<void>;
+  (message: string, cb?: TestCallback): void;
+};
+
+export type Modifier = {
+  (message: string, cb: AsyncTestCallback): Promise<void>;
+  (message: string, cb: TestCallback): void;
+  (cb: AsyncTestCallback): Promise<void>;
+  (cb: TestCallback): void;
+};

--- a/src/@types/poku.ts
+++ b/src/@types/poku.ts
@@ -189,10 +189,10 @@ export type Poku = {
   (targetPaths: string | string[], configs?: Configs): Promise<undefined>;
 };
 
-export type TestCallback = (
+export type TestCb = (
   params?: Record<string, unknown>
 ) => unknown | Promise<unknown>;
 
-export type AsyncTestCallback = (
+export type AsyncTestCb = (
   params?: Record<string, unknown>
 ) => Promise<unknown>;

--- a/src/@types/poku.ts
+++ b/src/@types/poku.ts
@@ -183,3 +183,7 @@ export type ConfigFile = Omit<Configs, 'noExit'> & CliConfigs;
 export type TestCallback = (
   params?: Record<string, unknown>
 ) => unknown | Promise<unknown>;
+
+export type AsyncTestCallback = (
+  params?: Record<string, unknown>
+) => Promise<unknown>;

--- a/src/@types/poku.ts
+++ b/src/@types/poku.ts
@@ -1,3 +1,4 @@
+import type { Code } from './code.js';
 import type { Configs as ListFilesConfigs } from './list-files.js';
 import type { PokuPlugin, ReporterPlugin } from './plugin.js';
 
@@ -179,6 +180,14 @@ export type ConfigJSONFile = {
   CliConfigs;
 
 export type ConfigFile = Omit<Configs, 'noExit'> & CliConfigs;
+
+export type Poku = {
+  (
+    targetPaths: string | string[],
+    configs: Configs & { noExit: true }
+  ): Promise<Code>;
+  (targetPaths: string | string[], configs?: Configs): Promise<undefined>;
+};
 
 export type TestCallback = (
   params?: Record<string, unknown>

--- a/src/builders/assert.ts
+++ b/src/builders/assert.ts
@@ -191,7 +191,7 @@ export const createAssert = (nodeAssert: typeof assert) => {
     });
   };
 
-  const assert = Object.assign(
+  return Object.assign(
     ((value, message?) => ok(value, message)) satisfies AssertValue,
     {
       ok,
@@ -213,6 +213,4 @@ export const createAssert = (nodeAssert: typeof assert) => {
       rejects,
     }
   );
-
-  return assert;
 };

--- a/src/builders/assert.ts
+++ b/src/builders/assert.ts
@@ -1,83 +1,54 @@
 import type assert from 'node:assert';
 import type { AssertPredicate } from 'node:assert';
-import type { ProcessAssertionOptions } from '../@types/assert.js';
+import type {
+  AssertEqual,
+  AssertionMessage,
+  AssertMatch,
+  AssertRejects,
+  AssertThrows,
+  AssertValue,
+  AsyncBlock,
+} from '../@types/assert.js';
 import { processAssert, processAsyncAssert } from '../services/assert.js';
 
 export const createAssert = (nodeAssert: typeof assert) => {
-  const ok = (
-    value: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void => processAssert(() => nodeAssert.ok(value), { message });
+  const ok: AssertValue = (value, message) =>
+    processAssert(() => nodeAssert.ok(value), { message });
 
-  const equal = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void => {
+  const equal: AssertEqual = (actual, expected, message) => {
     processAssert(() => nodeAssert.equal(actual, expected), { message });
   };
 
-  const deepEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const deepEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.deepEqual(actual, expected), { message });
 
-  const strictEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const strictEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.strictEqual(actual, expected), { message });
 
-  const deepStrictEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const deepStrictEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.deepStrictEqual(actual, expected), {
       message,
     });
 
-  const notEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const notEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.notEqual(actual, expected), {
       message,
     });
 
-  const notDeepEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const notDeepEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.notDeepEqual(actual, expected), { message });
 
-  const notStrictEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const notStrictEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.notStrictEqual(actual, expected), {
       message,
     });
 
-  const notDeepStrictEqual = (
-    actual: unknown,
-    expected: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const notDeepStrictEqual: AssertEqual = (actual, expected, message) =>
     processAssert(() => nodeAssert.notDeepStrictEqual(actual, expected), {
       message,
     });
 
-  const ifError = (
-    value: unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void =>
+  const ifError: AssertValue = (value, message) =>
     processAssert(() => nodeAssert.ifError(value), {
       message,
       defaultMessage: 'Expected no error, but received an error',
@@ -85,7 +56,7 @@ export const createAssert = (nodeAssert: typeof assert) => {
       throw: true,
     });
 
-  const fail = (message?: ProcessAssertionOptions['message']): never => {
+  const fail = (message?: AssertionMessage): never => {
     processAssert(() => nodeAssert.fail(message), {
       message,
       defaultMessage: 'Test failed intentionally',
@@ -95,20 +66,11 @@ export const createAssert = (nodeAssert: typeof assert) => {
     process.exit(1);
   };
 
-  function doesNotThrow(
+  const doesNotThrow: AssertThrows = ((
     block: () => unknown,
-    message?: string | ProcessAssertionOptions['message']
-  ): void;
-  function doesNotThrow(
-    block: () => unknown,
-    error: AssertPredicate,
-    message?: ProcessAssertionOptions['message']
-  ): void;
-  function doesNotThrow(
-    block: () => unknown,
-    errorOrMessage?: AssertPredicate | ProcessAssertionOptions['message'],
-    message?: ProcessAssertionOptions['message']
-  ): void {
+    errorOrMessage?: AssertPredicate | AssertionMessage,
+    message?: AssertionMessage
+  ): void => {
     processAssert(
       () => {
         if (
@@ -130,22 +92,13 @@ export const createAssert = (nodeAssert: typeof assert) => {
         throw: true,
       }
     );
-  }
+  }) as AssertThrows;
 
-  function throws(
+  const throws: AssertThrows = ((
     block: () => unknown,
-    message?: ProcessAssertionOptions['message']
-  ): void;
-  function throws(
-    block: () => unknown,
-    error: AssertPredicate,
-    message?: ProcessAssertionOptions['message']
-  ): void;
-  function throws(
-    block: () => unknown,
-    errorOrMessage?: AssertPredicate | ProcessAssertionOptions['message'],
-    message?: ProcessAssertionOptions['message']
-  ): void {
+    errorOrMessage?: AssertPredicate | AssertionMessage,
+    message?: AssertionMessage
+  ): void => {
     if (
       typeof errorOrMessage === 'function' ||
       errorOrMessage instanceof RegExp ||
@@ -166,22 +119,13 @@ export const createAssert = (nodeAssert: typeof assert) => {
         hideDiff: true,
       });
     }
-  }
+  }) as AssertThrows;
 
-  function rejects(
-    block: (() => Promise<unknown>) | Promise<unknown>,
-    message?: ProcessAssertionOptions['message']
-  ): Promise<void>;
-  function rejects(
-    block: (() => Promise<unknown>) | Promise<unknown>,
-    error: AssertPredicate,
-    message?: ProcessAssertionOptions['message']
-  ): Promise<void>;
-  async function rejects(
-    block: (() => Promise<unknown>) | Promise<unknown>,
-    errorOrMessage?: AssertPredicate | ProcessAssertionOptions['message'],
-    message?: ProcessAssertionOptions['message']
-  ): Promise<void> {
+  const rejects: AssertRejects = (async (
+    block: AsyncBlock,
+    errorOrMessage?: AssertPredicate | AssertionMessage,
+    message?: AssertionMessage
+  ): Promise<void> => {
     await processAsyncAssert(
       async () => {
         if (
@@ -203,22 +147,13 @@ export const createAssert = (nodeAssert: typeof assert) => {
         throw: true,
       }
     );
-  }
+  }) as AssertRejects;
 
-  function doesNotReject(
-    block: (() => Promise<unknown>) | Promise<unknown>,
-    message?: ProcessAssertionOptions['message']
-  ): Promise<void>;
-  function doesNotReject(
-    block: (() => Promise<unknown>) | Promise<unknown>,
-    error: AssertPredicate,
-    message?: ProcessAssertionOptions['message']
-  ): Promise<void>;
-  async function doesNotReject(
-    block: (() => Promise<unknown>) | Promise<unknown>,
-    errorOrMessage?: AssertPredicate | ProcessAssertionOptions['message'],
-    message?: ProcessAssertionOptions['message']
-  ): Promise<void> {
+  const doesNotReject: AssertRejects = (async (
+    block: AsyncBlock,
+    errorOrMessage?: AssertPredicate | AssertionMessage,
+    message?: AssertionMessage
+  ): Promise<void> => {
     await processAsyncAssert(
       async () => {
         if (
@@ -236,13 +171,9 @@ export const createAssert = (nodeAssert: typeof assert) => {
         throw: true,
       }
     );
-  }
+  }) as AssertRejects;
 
-  const match = (
-    value: string,
-    regExp: RegExp,
-    message?: ProcessAssertionOptions['message']
-  ): void => {
+  const match: AssertMatch = (value, regExp, message) => {
     processAssert(() => nodeAssert?.match(value, regExp), {
       message,
       actual: 'Value',
@@ -251,11 +182,7 @@ export const createAssert = (nodeAssert: typeof assert) => {
     });
   };
 
-  const doesNotMatch = (
-    value: string,
-    regExp: RegExp,
-    message?: ProcessAssertionOptions['message']
-  ): void => {
+  const doesNotMatch: AssertMatch = (value, regExp, message) => {
     processAssert(() => nodeAssert.doesNotMatch(value, regExp), {
       message,
       actual: 'Value',
@@ -265,8 +192,7 @@ export const createAssert = (nodeAssert: typeof assert) => {
   };
 
   const assert = Object.assign(
-    (value: unknown, message?: ProcessAssertionOptions['message']) =>
-      ok(value, message),
+    ((value, message?) => ok(value, message)) satisfies AssertValue,
     {
       ok,
       equal,

--- a/src/modules/essentials/poku.ts
+++ b/src/modules/essentials/poku.ts
@@ -1,6 +1,6 @@
 import type { Code } from '../../@types/code.js';
 import type { PokuPlugin } from '../../@types/plugin.js';
-import type { Configs, PluginContext } from '../../@types/poku.js';
+import type { Configs, PluginContext, Poku } from '../../@types/poku.js';
 import { join } from 'node:path';
 import { env, hrtime, stdout } from 'node:process';
 import { GLOBAL, results, timespan } from '../../configs/poku.js';
@@ -15,18 +15,10 @@ export const onSigint = (): void => {
 
 process.once('SIGINT', onSigint);
 
-export async function poku(
-  targetPaths: string | string[],
-  configs: Configs & { noExit: true }
-): Promise<Code>;
-export async function poku(
+export const poku = (async (
   targetPaths: string | string[],
   configs?: Configs
-): Promise<undefined>;
-export async function poku(
-  targetPaths: string | string[],
-  configs?: Configs
-): Promise<Code | undefined> {
+): Promise<Code | undefined> => {
   if (configs) GLOBAL.configs = { ...GLOBAL.configs, ...configs };
 
   env.POKU_RUNTIME = GLOBAL.runtime;
@@ -104,4 +96,4 @@ export async function poku(
   }
 
   if (GLOBAL.configs.noExit) return code;
-}
+}) as Poku;

--- a/src/modules/helpers/describe.ts
+++ b/src/modules/helpers/describe.ts
@@ -1,12 +1,16 @@
-import type { DescribeOptions } from '../../@types/describe.js';
+import type {
+  Describe,
+  DescribeOptions,
+  DescribeWithModifiers,
+} from '../../@types/describe.js';
 import { AssertionError } from 'node:assert';
 import process from 'node:process';
 import { indentation } from '../../configs/indentation.js';
 import { errorHoist, GLOBAL } from '../../configs/poku.js';
 import { checkOnly } from '../../parsers/callback.js';
 import { hasOnly } from '../../parsers/get-arg.js';
-import { getCallback, getTitle } from './it/core.js';
-import { onlyDescribe, skip, todo } from './modifiers.js';
+import { getCallback, getTitle } from '../../parsers/get-test-args.js';
+import { createOnlyDescribe, skip, todo } from './modifiers.js';
 
 const getOptions = (input: unknown): DescribeOptions | undefined =>
   !input || typeof input !== 'object' ? undefined : input;
@@ -75,18 +79,10 @@ export const describeBase = async (
   GLOBAL.runAsOnly = false;
 };
 
-async function describeCore(
-  message: string,
-  cb: () => Promise<unknown>
-): Promise<void>;
-function describeCore(message: string, cb: () => unknown): void;
-async function describeCore(cb: () => Promise<unknown>): Promise<void>;
-function describeCore(cb: () => unknown): void;
-function describeCore(message: string, options?: DescribeOptions): void;
-async function describeCore(
+const describeCore = (async (
   messageOrCb: string | (() => unknown | Promise<unknown>),
   cbOrOptions?: (() => unknown | Promise<unknown>) | DescribeOptions
-): Promise<void> {
+): Promise<void> => {
   if (typeof messageOrCb === 'string' && typeof cbOrOptions !== 'function')
     return describeBase(messageOrCb, cbOrOptions);
 
@@ -107,10 +103,10 @@ async function describeCore(
     return describeBase(messageOrCb, cbOrOptions);
 
   if (typeof messageOrCb === 'function') return describeBase(messageOrCb);
-}
+}) as Describe;
 
 export const describe = Object.assign(describeCore, {
   todo,
   skip,
-  only: onlyDescribe,
-});
+  only: createOnlyDescribe(describeBase),
+}) satisfies DescribeWithModifiers;

--- a/src/modules/helpers/describe.ts
+++ b/src/modules/helpers/describe.ts
@@ -1,8 +1,4 @@
-import type {
-  Describe,
-  DescribeOptions,
-  DescribeWithModifiers,
-} from '../../@types/describe.js';
+import type { Describe, DescribeOptions } from '../../@types/describe.js';
 import { AssertionError } from 'node:assert';
 import process from 'node:process';
 import { indentation } from '../../configs/indentation.js';
@@ -109,4 +105,4 @@ export const describe = Object.assign(describeCore, {
   todo,
   skip,
   only: createOnlyDescribe(describeBase),
-}) satisfies DescribeWithModifiers;
+});

--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -1,6 +1,6 @@
-import type { It, ItWithModifiers } from '../../../@types/it.js';
+import type { It } from '../../../@types/it.js';
 import type { ScopeHook } from '../../../@types/plugin.js';
-import type { TestCallback } from '../../../@types/poku.js';
+import type { TestCb } from '../../../@types/poku.js';
 import { AssertionError } from 'node:assert';
 import process from 'node:process';
 import { each } from '../../../configs/each.js';
@@ -18,8 +18,8 @@ const getScopeHook = (): ScopeHook | undefined =>
     | undefined;
 
 export const itBase = async (
-  titleOrCb: string | TestCallback,
-  callback?: TestCallback
+  titleOrCb: string | TestCb,
+  callback?: TestCb
 ): Promise<void> => {
   try {
     const title = getTitle(titleOrCb);
@@ -109,8 +109,8 @@ export const itBase = async (
 };
 
 const itCore = (async (
-  titleOrCb: string | TestCallback,
-  cb?: TestCallback
+  titleOrCb: string | TestCb,
+  cb?: TestCb
 ): Promise<void> => {
   if (GLOBAL.configs.testNamePattern && typeof titleOrCb === 'string') {
     if (!GLOBAL.configs.testNamePattern.test(titleOrCb)) return;
@@ -132,4 +132,4 @@ export const it = Object.assign(itCore, {
   todo,
   skip,
   only: createOnlyIt(itBase),
-}) satisfies ItWithModifiers;
+});

--- a/src/modules/helpers/it/core.ts
+++ b/src/modules/helpers/it/core.ts
@@ -1,3 +1,4 @@
+import type { It, ItWithModifiers } from '../../../@types/it.js';
 import type { ScopeHook } from '../../../@types/plugin.js';
 import type { TestCallback } from '../../../@types/poku.js';
 import { AssertionError } from 'node:assert';
@@ -6,15 +7,10 @@ import { each } from '../../../configs/each.js';
 import { indentation } from '../../../configs/indentation.js';
 import { errorHoist, GLOBAL } from '../../../configs/poku.js';
 import { hasOnly } from '../../../parsers/get-arg.js';
-import { onlyIt, skip, todo } from '../modifiers.js';
+import { getCallback, getTitle } from '../../../parsers/get-test-args.js';
+import { createOnlyIt, skip, todo } from '../modifiers.js';
 
 const SCOPE_HOOKS_KEY = Symbol.for('@pokujs/poku.test-scope-hooks');
-
-export const getTitle = (input: unknown): string | undefined =>
-  typeof input === 'string' ? input : undefined;
-
-export const getCallback = (input: unknown): TestCallback | undefined =>
-  typeof input === 'function' ? (input as TestCallback) : undefined;
 
 const getScopeHook = (): ScopeHook | undefined =>
   (globalThis as Record<symbol, unknown>)[SCOPE_HOOKS_KEY] as
@@ -112,22 +108,10 @@ export const itBase = async (
   }
 };
 
-async function itCore(
-  title: string,
-  cb: (params?: Record<string, unknown>) => Promise<unknown>
-): Promise<void>;
-function itCore(
-  title: string,
-  cb: (params?: Record<string, unknown>) => unknown
-): void;
-async function itCore(
-  cb: (params?: Record<string, unknown>) => Promise<unknown>
-): Promise<void>;
-function itCore(cb: (params?: Record<string, unknown>) => unknown): void;
-async function itCore(
+const itCore = (async (
   titleOrCb: string | TestCallback,
   cb?: TestCallback
-): Promise<void> {
+): Promise<void> => {
   if (GLOBAL.configs.testNamePattern && typeof titleOrCb === 'string') {
     if (!GLOBAL.configs.testNamePattern.test(titleOrCb)) return;
   }
@@ -142,10 +126,10 @@ async function itCore(
 
   if (typeof titleOrCb === 'string' && cb) return itBase(titleOrCb, cb);
   if (typeof titleOrCb === 'function') return itBase(titleOrCb);
-}
+}) as It;
 
 export const it = Object.assign(itCore, {
   todo,
   skip,
-  only: onlyIt,
-});
+  only: createOnlyIt(itBase),
+}) satisfies ItWithModifiers;

--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -1,7 +1,7 @@
 import type { Describe } from '../../@types/describe.js';
 import type { It } from '../../@types/it.js';
 import type { Modifier, Todo } from '../../@types/modifiers.js';
-import type { AsyncTestCallback, TestCallback } from '../../@types/poku.js';
+import type { AsyncTestCb, TestCb } from '../../@types/poku.js';
 import { exit } from 'node:process';
 import { GLOBAL } from '../../configs/poku.js';
 import { CheckNoOnly } from '../../parsers/callback.js';
@@ -10,8 +10,8 @@ import { format } from '../../services/format.js';
 import { log } from '../../services/write.js';
 
 export const todo = (async (
-  messageOrCb: string | TestCallback | AsyncTestCallback,
-  _cb?: TestCallback | AsyncTestCallback
+  messageOrCb: string | TestCb | AsyncTestCb,
+  _cb?: TestCb | AsyncTestCb
 ): Promise<void> => {
   const message = typeof messageOrCb === 'string' ? messageOrCb : 'Planning';
 
@@ -19,8 +19,8 @@ export const todo = (async (
 }) as Todo;
 
 export const skip = (async (
-  messageOrCb: string | TestCallback | AsyncTestCallback,
-  _cb?: TestCallback | AsyncTestCallback
+  messageOrCb: string | TestCb | AsyncTestCb,
+  _cb?: TestCb | AsyncTestCb
 ): Promise<void> => {
   const message = typeof messageOrCb === 'string' ? messageOrCb : 'Skipping';
 
@@ -29,8 +29,8 @@ export const skip = (async (
 
 export const createOnlyDescribe = (describeBase: Describe): Modifier =>
   (async (
-    messageOrCb: string | TestCallback | AsyncTestCallback,
-    cb?: TestCallback | AsyncTestCallback
+    messageOrCb: string | TestCb | AsyncTestCb,
+    cb?: TestCb | AsyncTestCb
   ): Promise<void> => {
     if (!hasOnly) {
       log(
@@ -52,8 +52,8 @@ export const createOnlyDescribe = (describeBase: Describe): Modifier =>
 
 export const createOnlyIt = (itBase: It): Modifier =>
   (async (
-    messageOrCb: string | TestCallback | AsyncTestCallback,
-    cb?: TestCallback | AsyncTestCallback
+    messageOrCb: string | TestCb | AsyncTestCb,
+    cb?: TestCb | AsyncTestCb
   ): Promise<void> => {
     if (!hasOnly) {
       log(

--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -1,90 +1,69 @@
+import type { Describe } from '../../@types/describe.js';
+import type { It } from '../../@types/it.js';
+import type { Modifier, Todo } from '../../@types/modifiers.js';
+import type { AsyncTestCallback, TestCallback } from '../../@types/poku.js';
 import { exit } from 'node:process';
 import { GLOBAL } from '../../configs/poku.js';
 import { CheckNoOnly } from '../../parsers/callback.js';
 import { hasOnly } from '../../parsers/get-arg.js';
 import { format } from '../../services/format.js';
 import { log } from '../../services/write.js';
-import { describeBase } from './describe.js';
-import { itBase } from './it/core.js';
 
-export function todo(message: string): void;
-export async function todo(
-  message: string,
-  cb?: () => Promise<unknown>
-): Promise<void>;
-export function todo(message: string, cb?: () => unknown): void;
-export async function todo(
-  messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
-  _cb?: (() => unknown) | (() => Promise<unknown>)
-): Promise<void> {
+export const todo = (async (
+  messageOrCb: string | TestCallback | AsyncTestCallback,
+  _cb?: TestCallback | AsyncTestCallback
+): Promise<void> => {
   const message = typeof messageOrCb === 'string' ? messageOrCb : 'Planning';
 
   GLOBAL.reporter.onTodoModifier({ message });
-}
+}) as Todo;
 
-export async function skip(
-  message: string,
-  cb: () => Promise<unknown>
-): Promise<void>;
-export function skip(message: string, cb: () => unknown): void;
-export async function skip(cb: () => Promise<unknown>): Promise<void>;
-export function skip(cb: () => unknown): void;
-export async function skip(
-  messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
-  _cb?: (() => unknown) | (() => Promise<unknown>)
-): Promise<void> {
+export const skip = (async (
+  messageOrCb: string | TestCallback | AsyncTestCallback,
+  _cb?: TestCallback | AsyncTestCallback
+): Promise<void> => {
   const message = typeof messageOrCb === 'string' ? messageOrCb : 'Skipping';
 
   GLOBAL.reporter.onSkipModifier({ message });
-}
+}) as Modifier;
 
-export async function onlyDescribe(
-  message: string,
-  cb: () => Promise<unknown>
-): Promise<void>;
-export function onlyDescribe(message: string, cb: () => unknown): void;
-export async function onlyDescribe(cb: () => Promise<unknown>): Promise<void>;
-export function onlyDescribe(cb: () => unknown): void;
-export async function onlyDescribe(
-  messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
-  cb?: (() => unknown) | (() => Promise<unknown>)
-): Promise<void> {
-  if (!hasOnly) {
-    log(format("Can't run `describe.only` tests without `--only` flag").fail());
-    exit(1);
-  }
+export const createOnlyDescribe = (describeBase: Describe): Modifier =>
+  (async (
+    messageOrCb: string | TestCallback | AsyncTestCallback,
+    cb?: TestCallback | AsyncTestCallback
+  ): Promise<void> => {
+    if (!hasOnly) {
+      log(
+        format("Can't run `describe.only` tests without `--only` flag").fail()
+      );
+      exit(1);
+    }
 
-  const noItOnly = CheckNoOnly(
-    typeof messageOrCb === 'function' ? messageOrCb : cb
-  );
-
-  if (noItOnly) GLOBAL.runAsOnly = true;
-
-  if (typeof messageOrCb === 'string' && cb)
-    return describeBase(messageOrCb, cb);
-  if (typeof messageOrCb === 'function') return describeBase(messageOrCb);
-}
-
-export async function onlyIt(
-  message: string,
-  cb: () => Promise<unknown>
-): Promise<void>;
-export function onlyIt(message: string, cb: () => unknown): void;
-export async function onlyIt(cb: () => Promise<unknown>): Promise<void>;
-export function onlyIt(cb: () => unknown): void;
-export async function onlyIt(
-  messageOrCb: string | (() => unknown) | (() => Promise<unknown>),
-  cb?: (() => unknown) | (() => Promise<unknown>)
-): Promise<void> {
-  if (!hasOnly) {
-    log(
-      format(
-        "Can't run `it.only` and `test.only` tests without `--only` flag"
-      ).fail()
+    const noItOnly = CheckNoOnly(
+      typeof messageOrCb === 'function' ? messageOrCb : cb
     );
-    exit(1);
-  }
 
-  if (typeof messageOrCb === 'string' && cb) return itBase(messageOrCb, cb);
-  if (typeof messageOrCb === 'function') return itBase(messageOrCb);
-}
+    if (noItOnly) GLOBAL.runAsOnly = true;
+
+    if (typeof messageOrCb === 'string' && cb)
+      return describeBase(messageOrCb, cb);
+    if (typeof messageOrCb === 'function') return describeBase(messageOrCb);
+  }) as Modifier;
+
+export const createOnlyIt = (itBase: It): Modifier =>
+  (async (
+    messageOrCb: string | TestCallback | AsyncTestCallback,
+    cb?: TestCallback | AsyncTestCallback
+  ): Promise<void> => {
+    if (!hasOnly) {
+      log(
+        format(
+          "Can't run `it.only` and `test.only` tests without `--only` flag"
+        ).fail()
+      );
+      exit(1);
+    }
+
+    if (typeof messageOrCb === 'string' && cb) return itBase(messageOrCb, cb);
+    if (typeof messageOrCb === 'function') return itBase(messageOrCb);
+  }) as Modifier;

--- a/src/parsers/get-test-args.ts
+++ b/src/parsers/get-test-args.ts
@@ -1,0 +1,7 @@
+import type { TestCallback } from '../@types/poku.js';
+
+export const getTitle = (input: unknown): string | undefined =>
+  typeof input === 'string' ? input : undefined;
+
+export const getCallback = (input: unknown): TestCallback | undefined =>
+  typeof input === 'function' ? (input as TestCallback) : undefined;

--- a/src/parsers/get-test-args.ts
+++ b/src/parsers/get-test-args.ts
@@ -1,7 +1,7 @@
-import type { TestCallback } from '../@types/poku.js';
+import type { TestCb } from '../@types/poku.js';
 
 export const getTitle = (input: unknown): string | undefined =>
   typeof input === 'string' ? input : undefined;
 
-export const getCallback = (input: unknown): TestCallback | undefined =>
-  typeof input === 'function' ? (input as TestCallback) : undefined;
+export const getCallback = (input: unknown): TestCb | undefined =>
+  typeof input === 'function' ? (input as TestCb) : undefined;

--- a/tools/build/dts.mts
+++ b/tools/build/dts.mts
@@ -1,0 +1,27 @@
+import { rm } from 'node:fs/promises';
+import { rollup } from 'rollup';
+import dts from 'rollup-plugin-dts';
+
+const ambientOutput = './lib/modules/_globals.d.ts';
+const bundle = await rollup({
+  input: {
+    'modules/index': './src/modules/index.ts',
+    'modules/plugins': './src/modules/plugins.ts',
+    'modules/_globals': './src/globals.d.ts',
+  },
+  plugins: [dts()],
+  external: (id) => id.startsWith('node:'),
+});
+
+await bundle.write({
+  dir: './lib',
+  format: 'es',
+  entryFileNames: '[name].d.ts',
+  chunkFileNames: 'modules/_shared.d.ts',
+  minifyInternalExports: false,
+  compact: true,
+  sourcemap: false,
+});
+
+await bundle.close();
+await rm(ambientOutput, { force: true });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,16 +17,15 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "noImplicitAny": true,
-    "removeComments": false,
+    "removeComments": true,
     "sourceMap": false,
     "esModuleInterop": true,
     "noEmitOnError": true,
-    "declaration": true,
-    "declarationDir": "lib",
+    "declaration": false,
     "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
While removing redundant types and improving the overload implementation to reduce build size, this exposed a **TDZ** circular dependency conflict between the modifiers and the `describe` and `it` methods.

Since it's not viable to solve one without the other, this _PR_ that previously aimed to improve the build size only by enhancing the project types, also fixes this newly exposed bug.