### PR TITLE
fix: improve `.only` logic to detect false positives

### DIFF
--- a/src/modules/helpers/modifiers.ts
+++ b/src/modules/helpers/modifiers.ts
@@ -4,7 +4,7 @@ import type { Modifier, Todo } from '../../@types/modifiers.js';
 import type { AsyncTestCb, TestCb } from '../../@types/poku.js';
 import { exit } from 'node:process';
 import { GLOBAL } from '../../configs/poku.js';
-import { CheckNoOnly } from '../../parsers/callback.js';
+import { checkNoOnly } from '../../parsers/callback.js';
 import { hasOnly } from '../../parsers/get-arg.js';
 import { format } from '../../services/format.js';
 import { log } from '../../services/write.js';
@@ -39,7 +39,7 @@ export const createOnlyDescribe = (describeBase: Describe): Modifier =>
       exit(1);
     }
 
-    const noItOnly = CheckNoOnly(
+    const noItOnly = checkNoOnly(
       typeof messageOrCb === 'function' ? messageOrCb : cb
     );
 

--- a/src/parsers/callback.ts
+++ b/src/parsers/callback.ts
@@ -1,23 +1,13 @@
+const onlyCall = /(?:^|[^.\w$])(?:it|test|describe)\.only\s*\(/;
+
 export const checkOnly = (cb: unknown): boolean => {
   if (typeof cb !== 'function') return false;
 
-  const body = cb.toString();
-
-  return (
-    body.includes('it.only') ||
-    body.includes('test.only') ||
-    body.includes('describe.only')
-  );
+  return onlyCall.test(cb.toString());
 };
 
 export const CheckNoOnly = (cb: unknown): boolean => {
   if (typeof cb !== 'function') return false;
 
-  const body = cb.toString();
-
-  return !(
-    body.includes('it.only') ||
-    body.includes('test.only') ||
-    body.includes('describe.only')
-  );
+  return !onlyCall.test(cb.toString());
 };

--- a/src/parsers/callback.ts
+++ b/src/parsers/callback.ts
@@ -3,11 +3,11 @@ const onlyCall = /(?:^|[^.\w$])(?:it|test|describe)\.only\s*\(/;
 export const checkOnly = (cb: unknown): boolean => {
   if (typeof cb !== 'function') return false;
 
-  return onlyCall.test(cb.toString());
+  return onlyCall.test(String(cb));
 };
 
 export const checkNoOnly = (cb: unknown): boolean => {
   if (typeof cb !== 'function') return false;
 
-  return !onlyCall.test(cb.toString());
+  return !onlyCall.test(String(cb));
 };

--- a/src/parsers/callback.ts
+++ b/src/parsers/callback.ts
@@ -6,7 +6,7 @@ export const checkOnly = (cb: unknown): boolean => {
   return onlyCall.test(cb.toString());
 };
 
-export const CheckNoOnly = (cb: unknown): boolean => {
+export const checkNoOnly = (cb: unknown): boolean => {
   if (typeof cb !== 'function') return false;
 
   return !onlyCall.test(cb.toString());

--- a/test/unit/parse-callbacks.test.ts
+++ b/test/unit/parse-callbacks.test.ts
@@ -2,7 +2,7 @@ import { assert } from '../../src/modules/essentials/assert.js';
 import { describe } from '../../src/modules/helpers/describe.js';
 import { it } from '../../src/modules/helpers/it/core.js';
 import { test } from '../../src/modules/helpers/test.js';
-import { CheckNoOnly, checkOnly } from '../../src/parsers/callback.js';
+import { checkNoOnly, checkOnly } from '../../src/parsers/callback.js';
 
 const cbWithOnly = {
   function: function cb() {
@@ -193,115 +193,115 @@ describe('Parse Callbacks: checkOnly — false', () => {
   );
 });
 
-describe('Parse Callbacks: CheckNoOnly — true', () => {
-  assert.strictEqual(CheckNoOnly(undefined), false, 'No function');
+describe('Parse Callbacks: checkNoOnly — true', () => {
+  assert.strictEqual(checkNoOnly(undefined), false, 'No function');
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.function),
+    checkNoOnly(cbWithoutOnly.function),
     true,
     'Classic Function: describe.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.function2),
+    checkNoOnly(cbWithoutOnly.function2),
     true,
     'Classic Function: it.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.function3),
+    checkNoOnly(cbWithoutOnly.function3),
     true,
     'Classic Function: test.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.anon),
+    checkNoOnly(cbWithoutOnly.anon),
     true,
     'Anonymous Function: describe.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.anon2),
+    checkNoOnly(cbWithoutOnly.anon2),
     true,
     'Anonymous Function: it.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.anon3),
+    checkNoOnly(cbWithoutOnly.anon3),
     true,
     'Anonymous Function: test.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.arrow),
+    checkNoOnly(cbWithoutOnly.arrow),
     true,
     'Arrow Function: describe.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.arrow2),
+    checkNoOnly(cbWithoutOnly.arrow2),
     true,
     'Arrow Function: it.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithoutOnly.arrow3),
+    checkNoOnly(cbWithoutOnly.arrow3),
     true,
     'Arrow Function: test.only'
   );
 });
 
-describe('Parse Callbacks: CheckNoOnly — false', () => {
+describe('Parse Callbacks: checkNoOnly — false', () => {
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.function),
+    checkNoOnly(cbWithOnly.function),
     false,
     'Classic Function: describe.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.function2),
+    checkNoOnly(cbWithOnly.function2),
     false,
     'Classic Function: it.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.function3),
+    checkNoOnly(cbWithOnly.function3),
     false,
     'Classic Function: test.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.anon),
+    checkNoOnly(cbWithOnly.anon),
     false,
     'Anonymous Function: describe.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.anon2),
+    checkNoOnly(cbWithOnly.anon2),
     false,
     'Anonymous Function: it.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.anon3),
+    checkNoOnly(cbWithOnly.anon3),
     false,
     'Anonymous Function: test.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.arrow),
+    checkNoOnly(cbWithOnly.arrow),
     false,
     'Arrow Function: describe.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.arrow2),
+    checkNoOnly(cbWithOnly.arrow2),
     false,
     'Arrow Function: it.only'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbWithOnly.arrow3),
+    checkNoOnly(cbWithOnly.arrow3),
     false,
     'Arrow Function: test.only'
   );
@@ -327,21 +327,21 @@ describe('Parse Callbacks: checkOnly (false positives)', () => {
   );
 });
 
-describe('Parse Callbacks: CheckNoOnly (false positives)', () => {
+describe('Parse Callbacks: checkNoOnly (false positives)', () => {
   assert.strictEqual(
-    CheckNoOnly(cbFalsePositives.stringDouble),
+    checkNoOnly(cbFalsePositives.stringDouble),
     true,
     'String literal: "it.only"'
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbFalsePositives.stringSingle),
+    checkNoOnly(cbFalsePositives.stringSingle),
     true,
     "String literal: 'test.only'"
   );
 
   assert.strictEqual(
-    CheckNoOnly(cbFalsePositives.stringTemplate),
+    checkNoOnly(cbFalsePositives.stringTemplate),
     true,
     'Template literal: `describe.only`'
   );

--- a/test/unit/parse-callbacks.test.ts
+++ b/test/unit/parse-callbacks.test.ts
@@ -64,6 +64,21 @@ const cbWithoutOnly = {
   },
 };
 
+const cbFalsePositives = {
+  stringDouble: () => {
+    const value = 'it.only';
+    return value;
+  },
+  stringSingle: () => {
+    const value = 'test.only';
+    return value;
+  },
+  stringTemplate: () => {
+    const value = `describe.only`;
+    return value;
+  },
+};
+
 describe('Parse Callbacks: checkOnly — true', () => {
   assert.strictEqual(checkOnly(undefined), false, 'No function');
 
@@ -289,5 +304,45 @@ describe('Parse Callbacks: CheckNoOnly — false', () => {
     CheckNoOnly(cbWithOnly.arrow3),
     false,
     'Arrow Function: test.only'
+  );
+});
+
+describe('Parse Callbacks: checkOnly (false positives)', () => {
+  assert.strictEqual(
+    checkOnly(cbFalsePositives.stringDouble),
+    false,
+    'String literal: "it.only"'
+  );
+
+  assert.strictEqual(
+    checkOnly(cbFalsePositives.stringSingle),
+    false,
+    "String literal: 'test.only'"
+  );
+
+  assert.strictEqual(
+    checkOnly(cbFalsePositives.stringTemplate),
+    false,
+    'Template literal: `describe.only`'
+  );
+});
+
+describe('Parse Callbacks: CheckNoOnly (false positives)', () => {
+  assert.strictEqual(
+    CheckNoOnly(cbFalsePositives.stringDouble),
+    true,
+    'String literal: "it.only"'
+  );
+
+  assert.strictEqual(
+    CheckNoOnly(cbFalsePositives.stringSingle),
+    true,
+    "String literal: 'test.only'"
+  );
+
+  assert.strictEqual(
+    CheckNoOnly(cbFalsePositives.stringTemplate),
+    true,
+    'Template literal: `describe.only`'
   );
 });

--- a/test/unit/parse-callbacks.test.ts
+++ b/test/unit/parse-callbacks.test.ts
@@ -65,17 +65,29 @@ const cbWithoutOnly = {
 };
 
 const cbFalsePositives = {
-  stringDouble: () => {
+  stringIt: () => {
     const value = 'it.only';
     return value;
   },
-  stringSingle: () => {
+  stringTest: () => {
     const value = 'test.only';
     return value;
   },
-  stringTemplate: () => {
-    const value = `describe.only`;
+  stringDescribe: () => {
+    const value = 'describe.only';
     return value;
+  },
+  prefixedIt: () => {
+    const _it = { only: () => {} };
+    _it.only();
+  },
+  prefixedTest: () => {
+    const _test = { only: () => {} };
+    _test.only();
+  },
+  prefixedDescribe: () => {
+    const _describe = { only: () => {} };
+    _describe.only();
   },
 };
 
@@ -309,40 +321,76 @@ describe('Parse Callbacks: checkNoOnly — false', () => {
 
 describe('Parse Callbacks: checkOnly (false positives)', () => {
   assert.strictEqual(
-    checkOnly(cbFalsePositives.stringDouble),
+    checkOnly(cbFalsePositives.stringIt),
     false,
-    'String literal: "it.only"'
+    "String literal: 'it.only'"
   );
 
   assert.strictEqual(
-    checkOnly(cbFalsePositives.stringSingle),
+    checkOnly(cbFalsePositives.stringTest),
     false,
     "String literal: 'test.only'"
   );
 
   assert.strictEqual(
-    checkOnly(cbFalsePositives.stringTemplate),
+    checkOnly(cbFalsePositives.stringDescribe),
     false,
-    'Template literal: `describe.only`'
+    "String literal: 'describe.only'"
+  );
+
+  assert.strictEqual(
+    checkOnly(cbFalsePositives.prefixedIt),
+    false,
+    'Similar identifier: _it.only()'
+  );
+
+  assert.strictEqual(
+    checkOnly(cbFalsePositives.prefixedTest),
+    false,
+    'Similar identifier: _test.only()'
+  );
+
+  assert.strictEqual(
+    checkOnly(cbFalsePositives.prefixedDescribe),
+    false,
+    'Similar identifier: _describe.only()'
   );
 });
 
 describe('Parse Callbacks: checkNoOnly (false positives)', () => {
   assert.strictEqual(
-    checkNoOnly(cbFalsePositives.stringDouble),
+    checkNoOnly(cbFalsePositives.stringIt),
     true,
-    'String literal: "it.only"'
+    "String literal: 'it.only'"
   );
 
   assert.strictEqual(
-    checkNoOnly(cbFalsePositives.stringSingle),
+    checkNoOnly(cbFalsePositives.stringTest),
     true,
     "String literal: 'test.only'"
   );
 
   assert.strictEqual(
-    checkNoOnly(cbFalsePositives.stringTemplate),
+    checkNoOnly(cbFalsePositives.stringDescribe),
     true,
-    'Template literal: `describe.only`'
+    "String literal: 'describe.only'"
+  );
+
+  assert.strictEqual(
+    checkNoOnly(cbFalsePositives.prefixedIt),
+    true,
+    'Similar identifier: _it.only()'
+  );
+
+  assert.strictEqual(
+    checkNoOnly(cbFalsePositives.prefixedTest),
+    true,
+    'Similar identifier: _test.only()'
+  );
+
+  assert.strictEqual(
+    checkNoOnly(cbFalsePositives.prefixedDescribe),
+    true,
+    'Similar identifier: _describe.only()'
   );
 });

--- a/website/docs/documentation/helpers/only.mdx
+++ b/website/docs/documentation/helpers/only.mdx
@@ -125,11 +125,11 @@ import { test } from 'poku';
 const run = test.only;
 
 run('aliased', () => {
-  // ⏭️ Won't be recognized as `it.only`
+  // ❌ Won't be recognized
 });
 
 test.only('direct', () => {
-  // ✅ Will be executed
+  // ✅ Will be recognized
 });
 ```
 

--- a/website/docs/documentation/helpers/only.mdx
+++ b/website/docs/documentation/helpers/only.mdx
@@ -115,6 +115,26 @@ npx poku --only
 
 ---
 
+### Intentional Limitations
+
+The `.only` modifier must be written directly on `it`, `test`, or `describe`. Aliasing it to another name or accessing it indirectly won't work because Poku doesn't track tests internally, as other test runners do. For example:
+
+```ts
+import { test } from 'poku';
+
+const run = test.only;
+
+run('aliased', () => {
+  // ⏭️ Won't be recognized as `it.only`
+});
+
+test.only('direct', () => {
+  // ✅ Will be executed
+});
+```
+
+---
+
 :::tip
 
 - The `.only` modifier works exactly as its respective `describe`, `it` and `test` methods (e.g., by running `beforeEach` and `afterEach` for the `test.only` or `it.only`).


### PR DESCRIPTION
Fixes #1095.

---

> <img width="545" height="256" alt="Screenshot 2026-05-20 at 17 11 34" src="https://github.com/user-attachments/assets/3b384fb0-08c4-40ef-bc16-2c53880b5f73" />
